### PR TITLE
expose suggestion scores

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -90,6 +90,8 @@ libaspell_la_SOURCES =\
   lib/find_speller.cpp\
   lib/speller-c.cpp\
   lib/string_pair_enumeration-c.cpp\
+  lib/suggestion_enumeration-c.cpp\
+  lib/suggestion_list-c.cpp\
   lib/new_checker.cpp
 
 libaspell_la_LIBADD =  $(LTLIBINTL) $(PTHREAD_LIB)

--- a/auto/MkSrc/ProcImpl.pm
+++ b/auto/MkSrc/ProcImpl.pm
@@ -1,5 +1,5 @@
 # This file is part of The New Aspell
-# Copyright (C) 2001-2002 by Kevin Atkinson under the GNU LGPL
+# Copyright (C) 2001-2006 by Kevin Atkinson under the GNU LGPL
 # license version 2.0 or 2.1.  You should have received a copy of the
 # LGPL license along with this library if you did not you can find it
 # at http://www.gnu.org/.
@@ -101,6 +101,11 @@ $info{class}{proc}{impl} = sub {
 	  $accum->{headers}{'word list'} = true;
           $ret .= "  if (ret.data)\n";
 	  $ret .= "    const_cast<WordList *>(ret.data)->from_internal_ = ths->from_internal_;\n";
+	}
+	if ($ret_type->{type} eq 'const suggestion list') {
+	  $accum->{headers}{'suggestion list'} = true;
+          $ret .= "  if (ret.data)\n";
+	  $ret .= "    const_cast<SuggestionList *>(ret.data)->from_internal_ = ths->from_internal_;\n";
 	}
 	$ret .= "  ";
 	$ret .= "return " unless $ret_type->{type} eq 'void';

--- a/auto/mk-src.in
+++ b/auto/mk-src.in
@@ -3,7 +3,7 @@
 #	       generate interface code.
 #
 # This file is part of The New Aspell
-# Copyright (C) 2001-2005 by Kevin Atkinson under the GNU LGPL
+# Copyright (C) 2001-2006 by Kevin Atkinson under the GNU LGPL
 # license version 2.0 or 2.1.  You should have received a copy of the
 # LGPL license along with this library if you did not you can find it
 # at http://www.gnu.org/.
@@ -714,9 +714,19 @@ class: speller
 		posib err
 		desc => Return NULL on error.
 			The word list returned by suggest is only
-			valid until the next call to suggest.
+			valid until the next call to suggest or scored_suggest.
 		/
 		const word list
+		encoded string: word
+
+	method: scored suggest
+
+		posib err
+		desc => Return NULL on error.
+			The word list returned by scored_suggest is only
+			valid until the next call to suggest or scored_suggest.
+		/
+		const suggestion list
 		encoded string: word
 
 	method: store replacement
@@ -905,6 +915,7 @@ group: string enumeration
 class: string enumeration
 	c impl headers => convert
 	/
+
 	copyable methods
 	method: at end
 		const
@@ -1063,6 +1074,96 @@ class: string pair enumeration
 	enumeration methods
 	copyable methods
 }
+
+group: suggestion
+{
+/
+struct: suggestion
+	/
+	string: word
+		default => ""
+	int: word len
+		default => 0
+	int: score
+		desc => How likely is this word given the original word?
+}
+group: suggestion enumeration
+{
+/
+class: suggestion enumeration
+	c impl headers => suggestion
+	/
+
+	cxx member: from internal
+		headers => convert
+		what => class Convert * from_internal_
+		default => 0
+		desc => Conversion routine to external representation.
+		/
+
+	cxx member: temp str
+		what => String temp_str_
+		default => ""
+		desc => Holds the string in external format when converted.
+		/
+
+	copyable methods
+
+	method: at end
+		const
+		/
+		bool
+
+	method: next
+		c impl =>
+			const Suggestion * s = ths->next();
+			if (s == 0 || ths->from_internal_ == 0) \{
+			  return s;
+			\} else \{
+			  ths->temp_str_.clear();
+			  ths->from_internal_->convert(s->word, -1, ths->temp_str_);
+			  ths->from_internal_->append_null(ths->temp_str_);
+			  (const_cast<Suggestion *>(s))->word = ths->temp_str_.data();
+			  return s;
+			\}
+		/
+		const suggestion
+}
+
+group: suggestion list
+{
+/
+class: suggestion list
+	c impl headers => suggestion enumeration
+	/
+	constructor
+
+	method: empty
+		const
+		/
+		bool
+
+	method: size
+		const
+		/
+		unsigned int
+
+	method: elements
+		const
+		c impl =>
+			SuggestionEnumeration * els = ths->elements();
+			els->from_internal_ = ths->from_internal_;
+			return els;
+		/
+		suggestion enumeration
+
+	copyable methods
+
+	cxx member: from internal
+		what => class Convert * from_internal_
+		default => 0
+}
+
 group: cache
 {
 /

--- a/auto/mk-src.in
+++ b/auto/mk-src.in
@@ -714,17 +714,17 @@ class: speller
 		posib err
 		desc => Return NULL on error.
 			The word list returned by suggest is only
-			valid until the next call to suggest or scored_suggest.
+			valid until the next call to suggest or suggest_plus.
 		/
 		const word list
 		encoded string: word
 
-	method: scored suggest
+	method: suggest plus
 
 		posib err
 		desc => Return NULL on error.
-			The word list returned by scored_suggest is only
-			valid until the next call to suggest or scored_suggest.
+			The word list returned by suggest_plus is only
+			valid until the next call to suggest or suggest_plus.
 		/
 		const suggestion list
 		encoded string: word

--- a/common/speller.hpp
+++ b/common/speller.hpp
@@ -1,5 +1,5 @@
 // This file is part of The New Aspell
-// Copyright (C) 2001 by Kevin Atkinson under the GNU LGPL license
+// Copyright (C) 2001-2006 by Kevin Atkinson under the GNU LGPL license
 // version 2.0 or 2.1.  You should have received a copy of the LGPL
 // license along with this library if you did not you can find
 // it at http://www.gnu.org/.
@@ -22,6 +22,7 @@
 #include "posib_err.hpp"
 #include "parm_string.hpp"
 #include "char_vector.hpp"
+#include "suggestion_list.hpp"
 
 namespace acommon {
 
@@ -107,9 +108,10 @@ namespace acommon {
     virtual PosibErr<void> clear_session() = 0;
 
     virtual PosibErr<const WordList *> suggest(MutableString) = 0;
+    virtual PosibErr<const SuggestionList *> scored_suggest(MutableString) = 0;
     // return null on error
     // the word list returned by suggest is only valid until the next
-    // call to suggest
+    // call to suggest or scored_suggest
   
     virtual PosibErr<void> store_replacement(MutableString, 
 					     MutableString) = 0;

--- a/common/speller.hpp
+++ b/common/speller.hpp
@@ -108,10 +108,10 @@ namespace acommon {
     virtual PosibErr<void> clear_session() = 0;
 
     virtual PosibErr<const WordList *> suggest(MutableString) = 0;
-    virtual PosibErr<const SuggestionList *> scored_suggest(MutableString) = 0;
+    virtual PosibErr<const SuggestionList *> suggest_plus(MutableString) = 0;
     // return null on error
     // the word list returned by suggest is only valid until the next
-    // call to suggest or scored_suggest
+    // call to suggest or suggest_plus
   
     virtual PosibErr<void> store_replacement(MutableString, 
 					     MutableString) = 0;

--- a/manual/aspell.texi
+++ b/manual/aspell.texi
@@ -2221,7 +2221,7 @@ AspellWordList * suggestions = aspell_speller_suggest(spell_checker,
                                                       @var{word}, @var{size});
 AspellStringEnumeration * elements = aspell_word_list_elements(suggestions);
 const char * word;
-while ( (word = aspell_string_enumeration_next(aspell_elements)) != NULL )
+while ( (word = aspell_string_enumeration_next(elements)) != NULL )
 @{
   // add to suggestion list
 @}
@@ -2230,7 +2230,30 @@ delete_aspell_string_enumeration(elements);
 
 Notice how @code{elements} is deleted but @code{suggestions} is not.
 The value returned by @code{suggestions} is only valid to the next
-call to @code{suggest}.  Once a replacement is made the
+call to @code{suggest}.
+
+If you want to sort the Aspell words by some additional criterion before
+presenting them, you should also take into account the ``score'' that
+Aspell used to sort them.  The score gives the ``distance'' of the
+suggestion from the original, with increasing scores giving increasing
+distances.  To cycle through a list of suggestions with scores,
+instead of the above example, copy this code:
+@smallexample
+AspellSuggestionList * suggestions = aspell_speller_scored_suggest(
+                                                      spell_checker,
+                                                      @var{word}, @var{size});
+AspellSuggestionEnumeration * elements =
+                              aspell_suggestion_list_elements(suggestions);
+const AspellSuggestion * sugg;
+while ( (sugg = aspell_suggestion_enumeration_next(elements)) != NULL )
+@{
+  // Add to suggestion list sugg->word, of length sugg->word_len, and
+  // with score sugg->score.
+@}
+delete_aspell_suggestion_enumeration(elements);
+@end smallexample
+
+Once a replacement is made the
 @code{store_repl} method should be used to communicate the replacement
 pair back to the spell checker (for the reason, @pxref{Notes on
 Storing Replacement Pairs}).  Its usage is as follows:

--- a/manual/aspell.texi
+++ b/manual/aspell.texi
@@ -2239,7 +2239,7 @@ suggestion from the original, with increasing scores giving increasing
 distances.  To cycle through a list of suggestions with scores,
 instead of the above example, copy this code:
 @smallexample
-AspellSuggestionList * suggestions = aspell_speller_scored_suggest(
+AspellSuggestionList * suggestions = aspell_speller_suggest_plus(
                                                       spell_checker,
                                                       @var{word}, @var{size});
 AspellSuggestionEnumeration * elements =

--- a/modules/speller/default/speller_impl.cpp
+++ b/modules/speller/default/speller_impl.cpp
@@ -133,9 +133,9 @@ namespace aspeller {
     return &suggest_->suggest(word);
   }
 
-  PosibErr<const SuggestionList *> SpellerImpl::scored_suggest(MutableString word) 
+  PosibErr<const SuggestionList *> SpellerImpl::suggest_plus(MutableString word) 
   {
-    return &suggest_->scored_suggest(word);
+    return &suggest_->suggest_plus(word);
   }
 
   bool SpellerImpl::check_simple (ParmString w, WordEntry & w0) 

--- a/modules/speller/default/speller_impl.cpp
+++ b/modules/speller/default/speller_impl.cpp
@@ -1,5 +1,5 @@
 // This file is part of The New Aspell
-// Copyright (C) 2000-2001,2011 by Kevin Atkinson under the GNU LGPL
+// Copyright (C) 2000-2006,2011 by Kevin Atkinson under the GNU LGPL
 // license version 2.0 or 2.1.  You should have received a copy of the
 // LGPL license along with this library if you did not you can find it
 // at http://www.gnu.org/.
@@ -131,6 +131,11 @@ namespace aspeller {
   PosibErr<const WordList *> SpellerImpl::suggest(MutableString word) 
   {
     return &suggest_->suggest(word);
+  }
+
+  PosibErr<const SuggestionList *> SpellerImpl::scored_suggest(MutableString word) 
+  {
+    return &suggest_->scored_suggest(word);
   }
 
   bool SpellerImpl::check_simple (ParmString w, WordEntry & w0) 
@@ -739,4 +744,3 @@ namespace aspeller {
     return new SpellerImpl();
   }
 }
-

--- a/modules/speller/default/speller_impl.hpp
+++ b/modules/speller/default/speller_impl.hpp
@@ -141,9 +141,9 @@ namespace aspeller {
     PosibErr<void> clear_session();
 
     PosibErr<const WordList *> suggest(MutableString word);
-    PosibErr<const SuggestionList *> scored_suggest(MutableString word);
+    PosibErr<const SuggestionList *> suggest_plus(MutableString word);
     // the suggestion list and the elements in it are only 
-    // valid until the next call to suggest or scored_suggest.
+    // valid until the next call to suggest or suggest_plus.
 
     PosibErr<void> store_replacement(MutableString mis, 
 				     MutableString cor);

--- a/modules/speller/default/speller_impl.hpp
+++ b/modules/speller/default/speller_impl.hpp
@@ -1,5 +1,5 @@
 // Aspell main C++ include file
-// Copyright 1998-2000 by Kevin Atkinson under the terms of the LGPL.
+// Copyright 1998-2006 by Kevin Atkinson under the terms of the LGPL.
 
 #ifndef __aspeller_speller__
 #define __aspeller_speller__
@@ -141,8 +141,9 @@ namespace aspeller {
     PosibErr<void> clear_session();
 
     PosibErr<const WordList *> suggest(MutableString word);
+    PosibErr<const SuggestionList *> scored_suggest(MutableString word);
     // the suggestion list and the elements in it are only 
-    // valid until the next call to suggest.
+    // valid until the next call to suggest or scored_suggest.
 
     PosibErr<void> store_replacement(MutableString mis, 
 				     MutableString cor);

--- a/modules/speller/default/suggest.cpp
+++ b/modules/speller/default/suggest.cpp
@@ -1365,7 +1365,7 @@ namespace {
       return -1;
     }
     SuggestWordList & suggest(const char * word);
-    SuggestionList & scored_suggest(const char * word);
+    SuggestionList & suggest_plus(const char * word);
   };
   
   PosibErr<void> SuggestImpl::setup(SpellerImpl * m)
@@ -1396,7 +1396,7 @@ namespace {
   }
 
   // Return a list of suggestions (with scores).
-  SuggestionList & SuggestImpl::scored_suggest(const char * word) {
+  SuggestionList & SuggestImpl::suggest_plus(const char * word) {
 #   ifdef DEBUG_SUGGEST
     COUT << "=========== begin suggest " << word << " ===========\n";
 #   endif
@@ -1412,7 +1412,7 @@ namespace {
 
   // Return a list of suggestions (without scores).
   SuggestWordList & SuggestImpl::suggest(const char * word) {
-    scored_suggest(word);
+    suggest_plus(word);
     return scored_suggestion_list.words;
   }
 

--- a/modules/speller/default/suggest.hpp
+++ b/modules/speller/default/suggest.hpp
@@ -34,7 +34,7 @@ namespace aspeller {
     virtual PosibErr<void> set_mode(ParmString) = 0;
     virtual double score(const char * base, const char * other) = 0;
     virtual SuggestWordList & suggest(const char * word) = 0;
-    virtual SuggestionList & scored_suggest(const char * word) = 0;
+    virtual SuggestionList & suggest_plus(const char * word) = 0;
     virtual ~Suggest() {}
   };
   

--- a/modules/speller/default/suggest.hpp
+++ b/modules/speller/default/suggest.hpp
@@ -1,4 +1,4 @@
-// Copyright 2000 by Kevin Atkinson under the terms of the LGPL
+// Copyright 2000-2006 by Kevin Atkinson under the terms of the LGPL
 
 #ifndef ASPELLER_SUGGEST__HPP
 #define ASPELLER_SUGGEST__HPP
@@ -13,27 +13,28 @@ namespace aspeller {
 
   class SpellerImpl;
 
-  class SuggestionList : public WordList {
+  class SuggestWordList : public WordList {
   public:
     typedef StringEnumeration            VirEmul;
     typedef Enumeration<VirEmul>         Emul;
     typedef const char *               Value;
     typedef unsigned int               Size;
 
-    virtual SuggestionList * clone() const = 0;
-    virtual void assign(const SuggestionList *) = 0;
+    virtual SuggestWordList * clone() const = 0;
+    virtual void assign(const SuggestWordList *) = 0;
     
     virtual bool empty() const = 0;
     virtual Size size() const = 0;
     virtual VirEmul * elements() const = 0;
-    virtual ~SuggestionList() {}
+    virtual ~SuggestWordList() {}
   };
 
   class Suggest {
   public:
     virtual PosibErr<void> set_mode(ParmString) = 0;
     virtual double score(const char * base, const char * other) = 0;
-    virtual SuggestionList & suggest(const char * word) = 0;
+    virtual SuggestWordList & suggest(const char * word) = 0;
+    virtual SuggestionList & scored_suggest(const char * word) = 0;
     virtual ~Suggest() {}
   };
   


### PR DESCRIPTION
Updated version of Ethan Bradford's patch from https://github.com/GNUAspell/aspell/issues/365
Renamed to `suggest_plus` as suggested at https://github.com/GNUAspell/aspell/issues/365#issuecomment-266261921