### PR TITLE
spelling fixes

### DIFF
--- a/auto/MkSrc/CcHelper.pm
+++ b/auto/MkSrc/CcHelper.pm
@@ -239,7 +239,7 @@ Parms is any of:
 
   mode: code generation mode
   no_aspell: if true do not include aspell in the name
-  this_name: name for the paramater representing the current object
+  this_name: name for the parameter representing the current object
 
 =item call_c_method CLASS ITEM PARMS ; %ACCUM
 

--- a/auto/MkSrc/Info.pm
+++ b/auto/MkSrc/Info.pm
@@ -58,7 +58,7 @@ each proc sub should take the following argv
   cxx impl: use this as the cxx impl instead of the default
   returns alt type: the constructor returns some type other than
     the object from which it is a member of
-  no native: do not attemt to create a native implementation
+  no native: do not attempt to create a native implementation
   treat as object: treat as a object rather than a pointer
 
 The %info structure is initialized as follows:

--- a/auto/mk-src.in
+++ b/auto/mk-src.in
@@ -817,7 +817,7 @@ class: document checker
 			The speller class is expected to last until
 			this class is destroyed.
 			If config is given it will be used to override
-			any relevent options set by this speller class.
+			any relevant options set by this speller class.
 			The config class is not once this function is done.
 			If filter is given then it will take ownership of
 			the filter class and use it to do the filtering.

--- a/common/block_slist.hpp
+++ b/common/block_slist.hpp
@@ -52,7 +52,7 @@ namespace acommon {
     }
 
     void remove_node(Node * n) 
-      // marks the node as availabe
+      // marks the node as available
       // Note: the node's data memeber destructor is NOT called
     {
       n->next = first_available;

--- a/common/config.cpp
+++ b/common/config.cpp
@@ -1354,7 +1354,7 @@ namespace acommon {
     {"actual-dict-dir", KeyInfoString, "<dict-dir^master>", 0}
     , {"actual-lang",     KeyInfoString, "", 0} 
     , {"conf",     KeyInfoString, "aspell.conf",
-       /* TRANSLATORS: The remaing strings in config.cpp should be kept
+       /* TRANSLATORS: The remaining strings in config.cpp should be kept
           under 50 characters, begin with a lower case character and not
           include any trailing punctuation marks. */
        N_("main configuration file")}

--- a/common/config.hpp
+++ b/common/config.hpp
@@ -72,7 +72,7 @@ namespace acommon {
   // -- setting a boolean value to an empty string is the same as setting 
   //    it to true
   //
-  // lset - sets a list, items seperated by ':'
+  // lset - sets a list, items separated by ':'
   // rem, remove - removes item from a list
   // add - add an item to a list
   // clear - removes all items from a list
@@ -207,7 +207,7 @@ namespace acommon {
 
     PosibErr<String> retrieve(ParmStr key) const;
 
-    // will also retrive a list, with one value per line
+    // will also retrieve a list, with one value per line
     PosibErr<String> retrieve_any(ParmStr key) const;
   
     bool have (ParmStr key) const;

--- a/common/fstream.hpp
+++ b/common/fstream.hpp
@@ -60,7 +60,7 @@ namespace acommon {
     // Will return false if there is no more data
     bool append_line(String &, char d);
 
-    // These perform raw io with any sort of formating
+    // These perform raw io with any sort of formatting
     bool read(void *, unsigned int i);
     void write(ParmStr);
     void write(char c);

--- a/common/objstack.hpp
+++ b/common/objstack.hpp
@@ -103,7 +103,7 @@ public:
   char * dup(ParmString str) {return dup_top(str);}
 
   // alloc_temp allocates an object from the bottom which can be
-  // resized untill it is commited.  If the resizing will involve
+  // resized until it is committed.  If the resizing will involve
   // moving the object than the data will be copied in the same way
   // realloc does.  Any previously allocated objects are aborted when
   // alloc_temp is called.

--- a/common/stack_ptr.hpp
+++ b/common/stack_ptr.hpp
@@ -22,7 +22,7 @@ namespace acommon {
     // and operator* and StackPtr(T *) will be used.  The explicit
     // doesn't protect us here due to PosibErr
     StackPtr(const StackPtr & other);
-    // becuase I am paranoid
+    // because I am paranoid
     StackPtr & operator=(const StackPtr & other);
 
   public:

--- a/common/string.hpp
+++ b/common/string.hpp
@@ -321,7 +321,7 @@ namespace acommon {
       erase(begin_ + pos, begin_ + pos + s);
     }
 
-    //FIXME: Make this more efficent by rewriting the implemenation
+    //FIXME: Make this more efficient by rewriting the implementation
     //       to work with raw memory rather than using vector<char>
     template <typename Itr>
     void replace(iterator start, iterator stop, Itr rstart, Itr rstop) 

--- a/manual/aspell-dev.texi
+++ b/manual/aspell-dev.texi
@@ -741,7 +741,7 @@ have to fulfill in order to implicitly activate the entire mode
 at least one such line is required.  Each magic line has the following
 format:
 @example
-MAGIC /<magic key>/<fileextention>[/<fileextention>]
+MAGIC /<magic key>/<fileextension>[/<fileextension>]
 @end example
 
 The magic key consist of three `:' separated fields.
@@ -754,8 +754,8 @@ If mode selection should only occurred on basis of the listed file
 extensions the magic key should consist of the ``<noregex>'' special
 string.
 
-At least one <fileextention> is required per MAGIC line.
-<fileextention> may not be empty and should not contain a leading `.'
+At least one <fileextension> is required per MAGIC line.
+<fileextension> may not be empty and should not contain a leading `.'
 as this is assumed implicitly.
 
 Multiple MAGIC lines are allowed. Modes may be extended limited by additional

--- a/manual/mksrc.texi
+++ b/manual/mksrc.texi
@@ -62,7 +62,7 @@ The format of @file{mk-src.in} is as follows:
     cxx impl: use this as the cxx impl instead of the default
     returns alt type: the constructor returns some type other than
       the object from which it is a member of
-    no native: do not attemt to create a native implementation
+    no native: do not attempt to create a native implementation
     treat as object: treat as a object rather than a pointer
 @end verbatim
     The @code{%info} structure is initialized as follows:

--- a/modules/filter/sgml.cpp
+++ b/modules/filter/sgml.cpp
@@ -5,7 +5,7 @@
 // license along with this library if you did not you can find
 // it at http://www.gnu.org/.
 //
-// The orignal filter was written by Kevin Atkinson.
+// The original filter was written by Kevin Atkinson.
 // Tom Snyder rewrote the filter to support skipping SGML tags
 //
 // This filter enables the spell checking of sgml, html, and xhtml files

--- a/modules/speller/default/affix.cpp
+++ b/modules/speller/default/affix.cpp
@@ -202,7 +202,7 @@ struct CondsLookupParms {
 typedef HashTable<CondsLookupParms> CondsLookup;
 
 // normalizes and checks the cond_str
-// returns the lenth of the new string or -1 if invalid
+// returns the length of the new string or -1 if invalid
 static int normalize_cond_str(char * str)
 {
   char * s = str;
@@ -452,7 +452,7 @@ PosibErr<void> AffixMgr::parse_file(const char * affpath, Conv & iconv)
   // prefix is not found (call it nextne).
 
   // Since we have built ordered lists, all that remains is to
-  // properly intialize the nextne and nexteq pointers that relate
+  // properly initialize the nextne and nexteq pointers that relate
   // them
 
   process_pfx_order();
@@ -1404,7 +1404,7 @@ specific character position in the word.
 For prefixes, it does this by setting bit 0 if that char is valid 
 in the first position, bit 1 if valid in the second position, and so on. 
 
-If a bit is not set, then that char is not valid for that postion in the
+If a bit is not set, then that char is not valid for that position in the
 word.
 
 If working with suffixes bit 0 is used for the character closest 

--- a/modules/speller/default/data.hpp
+++ b/modules/speller/default/data.hpp
@@ -114,10 +114,10 @@ namespace aspeller {
     bool soundslike_root_only; // true when affix compression is used AND
                                // the stored soundslike corresponds to the
                                // root word only
-    bool fast_scan;  // can effectly scan for all soundslikes (or
+    bool fast_scan;  // can effectively scan for all soundslikes (or
                      // clean words if have_soundslike is false)
                      // with an edit distance of 1 or 2
-    bool fast_lookup; // can effectly find all words with a given soundslike
+    bool fast_lookup; // can effectively find all words with a given soundslike
                       // when the SoundslikeWord is not given
     
     typedef WordEntryEnumeration        Enum;

--- a/modules/speller/default/leditdist.hpp
+++ b/modules/speller/default/leditdist.hpp
@@ -27,7 +27,7 @@ namespace aspeller {
   // respectfully.
 
   // The running time is asymptotically bounded above by 
-  // (3^l)*n where l is the limit and n is the maxium of strlen(a),strlen(b)
+  // (3^l)*n where l is the limit and n is the maximum of strlen(a),strlen(b)
   // Based on my informal tests, however, the n does not really matter
   // and the running time is more like (3^l).
 

--- a/modules/speller/default/suggest.cpp
+++ b/modules/speller/default/suggest.cpp
@@ -82,7 +82,7 @@ namespace {
   }
   
   //
-  // OriginalWord stores infomation about the original misspelled word
+  // OriginalWord stores information about the original misspelled word
   //   for convince and speed.
   //
   struct OriginalWord {
@@ -380,7 +380,7 @@ namespace {
 
   // Forms a word by combining CheckInfo fields.
   // Will grow the grow the temp in the buffer.  The final
-  // word must be null terminated and commited.
+  // word must be null terminated and committed.
   // It returns a MutableString of what was appended to the buffer.
   MutableString Working::form_word(CheckInfo & ci) 
   {
@@ -478,7 +478,7 @@ namespace {
         t[0] = lang->to_lower(t[0]);
     }
     char * end = (char *)buffer.grow_temp(1);
-    char * beg = (char *)buffer.temp_ptr(); // since the orignal string may of moved
+    char * beg = (char *)buffer.temp_ptr(); // since the original string may of moved
     *end = 0;
     buffer.commit_temp();
     add_nearmiss(beg, end - beg, 0, 0, score, -1, do_count);

--- a/modules/speller/default/vector_hash.hpp
+++ b/modules/speller/default/vector_hash.hpp
@@ -29,7 +29,7 @@ namespace aspeller {
   
   ////////////////////////////////////////////////////////
   //                                                    //
-  //          Vector Hash Table Interator               //
+  //          Vector Hash Table Iterator               //
   //                                                    //
   ////////////////////////////////////////////////////////
   //

--- a/myspell/README
+++ b/myspell/README
@@ -1,4 +1,4 @@
-This directory contains some utilites and documentation from the
+This directory contains some utilities and documentation from the
 standalone MySpell utility with some minor modifications.
 
 You can find MySpell at

--- a/prog/aspell.cpp
+++ b/prog/aspell.cpp
@@ -252,7 +252,7 @@ Conv uiconv;
 
 int main (int argc, const char *argv[]) 
 {
-  options = new_config(); // this needs to be here becuase of a bug
+  options = new_config(); // this needs to be here because of a bug
                           // with static initlizers on Darwin.
 #ifdef USE_LOCALE
   setlocale (LC_ALL, "");
@@ -1992,7 +1992,7 @@ void munch_list_simple()
       ci = ci->next;
     }
     // now add the base to the keep list if one exists
-    // otherwise just keep the orignal word
+    // otherwise just keep the original word
     if (best) {
       SML_Table::iterator b = table.find(best->word);
       assert(b != table.end());
@@ -2637,7 +2637,7 @@ void munch_list_complete(bool multi, bool simplify)
       if (working.size() > 0 && working.size() == prev_working_size)
       {
         to_keep.push_back(working[0]);
-        //CERR.printf("Making greedy choice! Chosing %s/%s.\n",
+        //CERR.printf("Making greedy choice! Choosing %s/%s.\n",
         //            working[0]->word, working[0]->aff);
         merge(to_keep_exp, working[0]->exp);
         working.erase(working.begin(), working.begin() + 1);

--- a/scripts/munchlist
+++ b/scripts/munchlist
@@ -73,7 +73,7 @@
 #		2/28/87
 #
 # 2004/02/11 kevina
-# Modifed to work with Aspell instead of Ispell
+# Modified to work with Aspell instead of Ispell
 #
 # Revision 1.3  2003/11/09 17:27:51  ed
 # Fix (based on Debian's) for insecure temporary file created in findaffix

--- a/scripts/spell
+++ b/scripts/spell
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# aspell list mimicks the standard unix spell program, roughly.
+# aspell list mimics the standard unix spell program, roughly.
 
 cat "$@" | aspell list --mode=none | sort -u
 


### PR DESCRIPTION
patch contains some spelling fixes ( just in comments ) as found by a bot ( http://www.misfix.org, https://github.com/ka7/misspell_fixer ). Any upcoming License changes (e.g. GPL2 to GPL3+) are hereby granted.