### PR TITLE
Fix system crash and continuous disk filling when processing "infinitely large" files

### DIFF
--- a/common/file_util.cpp
+++ b/common/file_util.cpp
@@ -148,6 +148,14 @@ namespace acommon {
     return ACCESS(name, F_OK) == 0;
   }
 
+  bool is_regular_file(String name) {
+    struct stat sb;
+    if(stat(name.c_str(), &sb) != 0) {
+      return false;
+    }
+    return S_ISREG(sb.st_mode) != 0;
+  }
+
   bool rename_file(ParmString orig_name, ParmString new_name)
   {
     remove(new_name);

--- a/common/file_util.hpp
+++ b/common/file_util.hpp
@@ -32,6 +32,7 @@ namespace acommon {
   void truncate_file(FStream & f, ParmString name);
   bool remove_file(ParmString name);
   bool file_exists(ParmString name);
+  bool is_regular_file(String name);
   bool rename_file(ParmString orig, ParmString new_name);
   // will return NULL if path is NULL.
   const char * get_file_name(const char * path);

--- a/prog/aspell.cpp
+++ b/prog/aspell.cpp
@@ -980,6 +980,11 @@ void check()
   new_name = file_name;
   new_name += ".new";
 
+  if(!is_regular_file(file_name )) {
+    print_error(_("\"%s\" is not a regular file"), file_name);
+    exit(-1);
+  }
+
   in = fopen(file_name.c_str(), "r");
   if (!in) {
     print_error(_("Could not open the file \"%s\" for reading"), file_name);


### PR DESCRIPTION
There is a situation where aspell can be made to hang processing an “infinitely large” file rendering the user interface inoperable and growing the <filename>.new temporary file until it fills the users disk (potentially preventing the user's machine from working correctly).  The situation occurs when aspell is handed a file like /dev/urandom through a symlink.  Aspell does not detect that this file is unusual and attempts to process it.  Once the user interface is presented using either the exit or abort commands causes the application to hang as described above.  This pull request adds a check that uses stat() to ensure the file being checked is a regular file and terminate execution.

This situation was found as part of an effort to detect and deal with “environmental” bugs in popular applications (for more information, check out https://works-everywhere.org). I have analyzed Aspell with a tool that detects situations where an application fails to correctly handle unusual environmental conditions such as file having an unexpected file type.