### PR TITLE
cache: Attempt to prevent premature destruction of global cache lock

### DIFF
--- a/common/cache-t.hpp
+++ b/common/cache-t.hpp
@@ -16,6 +16,8 @@ public: // but don't use
   const char * name;
   GlobalCacheBase * next;
   GlobalCacheBase * * prev;
+  // The global cache lock must exist while any cache instance is active
+  static Mutex global_cache_lock;
 protected:
   Cacheable * first;
   void del(Cacheable * d);

--- a/common/cache.cpp
+++ b/common/cache.cpp
@@ -5,8 +5,8 @@
 
 namespace acommon {
 
-static StackPtr<Mutex> global_cache_lock(new Mutex);
 static GlobalCacheBase * first_cache = 0;
+Mutex GlobalCacheBase::global_cache_lock;
 
 void Cacheable::copy() const
 {
@@ -70,7 +70,7 @@ void release_cache_data(GlobalCacheBase * cache, const Cacheable * d)
 GlobalCacheBase::GlobalCacheBase(const char * n)
   : name (n)
 {
-  LOCK(global_cache_lock);
+  LOCK(&global_cache_lock);
   next = first_cache;
   prev = &first_cache;
   if (first_cache) first_cache->prev = &next;
@@ -80,14 +80,14 @@ GlobalCacheBase::GlobalCacheBase(const char * n)
 GlobalCacheBase::~GlobalCacheBase()
 {
   detach_all();
-  LOCK(global_cache_lock);
+  LOCK(&global_cache_lock);
   *prev = next;
   if (next) next->prev = prev;
 }
 
 bool reset_cache(const char * which)
 {
-  LOCK(global_cache_lock);
+  LOCK(&GlobalCacheBase::global_cache_lock);
   bool any = false;
   for (GlobalCacheBase * i = first_cache; i; i = i->next)
   {


### PR DESCRIPTION
https://stackoverflow.com/questions/335369/finding-c-static-initialization-order-problems#335746

Probably fixes #531 

Previously:
* The destructor for `global_cache_lock` would run before the destructor for GlobalCacheBase (base class for GlobalCache, which is used in various places) - meaning that it was trying to lock/unlock on the already destroyed `global_cache_lock`