### PR TITLE
initial appveyor.yml for windows CI builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,90 @@
+version: 0.60.6.1.{build}
+image: Visual Studio 2015
+
+environment:
+    matrix:
+        - PlatformToolset: mingw-w64
+
+platform:
+    #- x64
+    - x86
+
+configuration:
+    - Release
+    #- Debug
+
+install:
+    - if "%platform%"=="x64" set archi=amd64
+    - if "%platform%"=="x86" set archi=x86
+    - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" %archi%
+
+    - ps: |
+        if ($env:PLATFORMTOOLSET -match "mingw-w64") {
+            if($env:PLATFORM -match "x86") {
+                $env:Path += ";C:\mingw-w64\i686-6.3.0-posix-dwarf-rt_v5-rev1\mingw32\bin"
+                $env:Path += ";C:\mingw-w64\i686-6.3.0-posix-dwarf-rt_v5-rev1\mingw32\i686-w64-mingw32\lib"
+            }
+            if($env:PLATFORM -match "x64") {
+                $env:Path += ";C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev1\mingw64\bin"
+                $env:Path += ";C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev1\mingw64\x86_64-w64-mingw32\lib"
+            }
+            $env:Path += ";C:\cygwin64\bin"
+            $env:Path = $env:Path.Replace('C:\Program Files\Git\usr\bin;','')
+            g++ --version
+            mingw32-make --version
+        }
+build:
+    parallel: true
+    verbosity: minimal
+
+before_build:
+- ps: |
+    Write-Output "Configuration: $env:CONFIGURATION"
+    Write-Output "Platform: $env:PLATFORM"
+
+build_script:
+- cd "%APPVEYOR_BUILD_FOLDER%"
+- cd auto
+- perl mk-src.pl
+- cd "%APPVEYOR_BUILD_FOLDER%"\win32
+- ps: |
+    mingw32-make
+    mingw32-make install
+
+after_build:
+- cd "%APPVEYOR_BUILD_FOLDER%"
+- ps: |
+
+    if ($env:PLATFORMTOOLSET -match "mingw-w64")
+    {
+        Push-AppveyorArtifact "c:/aspell/aspell.exe" -FileName "aspell.exe"
+        Push-AppveyorArtifact "c:/aspell/aspell-15.dll" -FileName "aspell-15.dll"
+
+        if ($($env:APPVEYOR_REPO_TAG) -eq "true" -and $env:PLATFORMTOOLSET -eq "mingw-w64" -and $env:CONFIGURATION -eq "Release")
+        {
+            $ZipFileName = "aspell_$($env:APPVEYOR_REPO_TAG_NAME)_$env:PLATFORM.zip"
+            md deploy -Force | Out-Null
+            md deploy\aspell -Force | Out-Null
+            Copy-Item c:/aspell/*.* deploy\aspell\
+            7z a $ZipFileName .\deploy\*
+            Remove-Item deploy\aspell\*.*
+        }
+    }
+
+artifacts:
+  - path: aspell_*.zip
+    name: releases
+
+deploy:
+    provider: GitHub
+    description: ''
+    auth_token:
+        secure: TODO
+    artifact: releases
+    draft: false
+    prerelease: false
+    force_update: true
+    on:
+        appveyor_repo_tag: true
+        PlatformToolset: mingw-w64
+        configuration: Release

--- a/common/file_util.cpp
+++ b/common/file_util.cpp
@@ -13,6 +13,7 @@
 #include "fstream.hpp"
 #include "errors.hpp"
 #include "string_list.hpp"
+#include "asc_ctype.hpp"
 
 #ifdef USE_FILE_LOCKS
 #  include <fcntl.h>

--- a/win32/Makefile
+++ b/win32/Makefile
@@ -62,12 +62,12 @@ ifdef WIN32_RELOCATABLE
 endif
 
 # cygwin: built native w32 code
-NOCYGWIN=-mno-cygwin
+#NOCYGWIN=-mno-cygwin
 
 ################################################################################
 
 LIBVERSION=15
-ASPELLVERSION=0-50-3
+ASPELLVERSION=0-60-6
 
 CCOMPILER=gcc
 CPPCOMPILER=g++
@@ -88,6 +88,8 @@ VPATH=	$(top_srcdir)/common:\
 	$(top_srcdir)/modules/speller/default:\
 	$(top_srcdir)/modules/tokenizer:\
 	$(top_srcdir)/lib:\
+	$(top_srcdir)/gen:\
+	$(top_srcdir)/win32/gen:\
 	$(top_srcdir)/prog
 INCLUDES = \
 	-I. \
@@ -96,6 +98,8 @@ INCLUDES = \
 	-I$(top_srcdir)/modules/filter \
 	-I$(top_srcdir)/modules/speller/default \
 	-I$(top_srcdir)/modules/tokenizer \
+	-I$(top_srcdir)/gen \
+	-I$(top_srcdir)/win32 \
 	$(CURSES_INCLUDE)
 
 FLAGS=$(DEBUGFLAG) $(BITFIELD) $(NOCYGWIN) $(OPTIMIZATION)
@@ -139,14 +143,15 @@ clean: \
 ASPELL_COMMON_A_NAME=aspell-common-$(ASPELLVERSION).a
 
 aspell_common_OBJECTS = \
+	cache.o \
 	string.o \
 	getdata.o \
 	itemize.o \
 	file_util.o \
-	string_buffer.o \
 	string_map.o \
 	string_list.o \
 	config.o \
+	version.o \
 	posib_err.o \
 	errors.o \
 	error.o \
@@ -159,16 +164,21 @@ aspell_common_OBJECTS = \
 	speller.o \
 	document_checker.o \
 	filter.o \
-	strtonum.o
+	objstack.o \
+	strtonum.o \
+	gettext_init.o \
+	file_data_util.o
 
+
+cache.o:	cache.cpp
 string.o:	string.cpp
 getdata.o:	getdata.cpp
 itemize.o:	itemize.cpp
 file_util.o:	file_util.cpp
-string_buffer.o:	string_buffer.cpp
 string_map.o:	string_map.cpp
 string_list.o:	string_list.cpp
 config.o:	config.cpp
+version.o:	version.cpp
 posib_err.o:	posib_err.cpp
 errors.o:	errors.cpp
 error.o:	error.cpp
@@ -181,29 +191,26 @@ tokenizer.o:	tokenizer.cpp
 speller.o:	speller.cpp
 document_checker.o:	document_checker.cpp
 filter.o:	filter.cpp
+objstack.o:	objstack.cpp
 strtonum.o:	strtonum.cpp
+gettext_init.o:	gettext_init.cpp
+file_data_util.o:	file_data_util.cpp
 
-dirs.h: mk-dirs_h
-	echo '#define PREFIX "${prefix}"'            >  dirs.h
-	./mk-dirs_h ${prefix} DICT_DIR ${pkglibdir}  >> dirs.h
-	./mk-dirs_h ${prefix} DATA_DIR ${pkgdatadir} >> dirs.h
-	./mk-dirs_h ${prefix} CONF_DIR ${sysconfdir} >> dirs.h
 
-mk-dirs_h: mk-dirs_h.cpp
-	$(NATIVE_CXX) $< $(LIBS) -o $@
+gen/dirs.h:
+	perl ${top_srcdir}/gen/mk-dirs_h.pl ${prefix} ${pkgdatadir} ${pkglibdir}  ${sysconfdir} >  ${top_srcdir}/gen/dirs.h
 
-config.cpp: dirs.h
+${top_srcdir}/common/config.cpp: gen/dirs.h
 
 aspell_common_a: $(ASPELL_COMMON_A_NAME) 
-$(ASPELL_COMMON_A_NAME): dirs.h $(aspell_common_OBJECTS)
+$(ASPELL_COMMON_A_NAME): gen/dirs.h $(aspell_common_OBJECTS)
 	$(AR) $(ARFLAGS) \
 	$@ \
 	$(aspell_common_OBJECTS)
 aspell_common_clean:
 	-rm $(aspell_common_OBJECTS) \
 	$(ASPELL_COMMON_A_NAME) \
-	mk-dirs_h.exe mk-dirs_h \
-	dirs.h
+	${top_srcdir}/gen/dirs.h
 
 #######################################################################
 # {{{1	aspell-filter-standard
@@ -213,15 +220,21 @@ aspell_filter_standard_EXTRALIBS = \
 	$(ASPELL_COMMON_A_NAME)
 
 aspell_filter_standard_OBJECTS = \
-	email.o \
 	url.o \
+	email.o \
 	tex.o \
 	sgml.o \
+	context.o \
+	nroff.o \
+	texinfo.o \
 
-email.o:	email.cpp
 url.o:	url.cpp
+email.o:	email.cpp
 tex.o:	tex.cpp
 sgml.o:	sgml.cpp
+context.o:	context.cpp
+nroff.o:	nroff.cpp
+texinfo.o:	texinfo.cpp
 
 aspell_filter_standard_a: $(ASPELL_FILTER_STANDARD_A_NAME)
 $(ASPELL_FILTER_STANDARD_A_NAME): $(aspell_filter_standard_OBJECTS)
@@ -240,43 +253,35 @@ aspell_speller_default_EXTRALIBS = \
 	$(ASPELL_COMMON_A_NAME)
 
 aspell_speller_default_OBJECTS = \
-	data.o \
-	leditdist.o \
-	primes.o \
-	writable_base.o \
-	editdist.o \
-	speller_impl.o \
 	readonly_ws.o \
-	writable_repl.o \
-	file_data_util.o \
-	multi_ws.o \
-	split.o \
-	writable_ws.o \
-	l2editdist.o \
-	phonet.o \
 	suggest.o \
-	language.o \
+	data.o \
+	multi_ws.o \
 	phonetic.o \
+	writable.o \
+	speller_impl.o \
+	phonet.o \
 	typo_editdist.o \
+	editdist.o \
+	primes.o \
+	language.o \
+	leditdist.o \
+	affix.o \
 
-data.o:	data.cpp
-leditdist.o:	leditdist.cpp
-primes.o:	primes.cpp
-writable_base.o:	writable_base.cpp
-editdist.o:	editdist.cpp
-speller_impl.o:	speller_impl.cpp
 readonly_ws.o:	readonly_ws.cpp
-writable_repl.o:	writable_repl.cpp
-file_data_util.o:	file_data_util.cpp
-multi_ws.o:	multi_ws.cpp
-split.o:	split.cpp
-writable_ws.o:	writable_ws.cpp
-l2editdist.o:	l2editdist.cpp
-phonet.o:	phonet.cpp
 suggest.o:	suggest.cpp
-language.o:	language.cpp
+data.o:	data.cpp
+multi_ws.o:	multi_ws.cpp
 phonetic.o:	phonetic.cpp
+writable.o:	writable.cpp
+speller_impl.o:	speller_impl.cpp
+phonet.o:	phonet.cpp
 typo_editdist.o:	typo_editdist.cpp
+editdist.o:	editdist.cpp
+primes.o:	primes.cpp
+language.o:	language.cpp
+leditdist.o:	leditdist.cpp
+affix.o:	affix.cpp
 
 aspell_speller_default_a: $(ASPELL_SPELLER_DEFAULT_A_NAME)
 $(ASPELL_SPELLER_DEFAULT_A_NAME): $(aspell_speller_default_OBJECTS)
@@ -338,34 +343,58 @@ aspell_dll_OBJECTS = \
 	string_pair_enumeration-c.o \
 	find_speller.o \
 	new_checker.o \
-	new_filter.o \
 	new_config.o \
 	string_enumeration-c.o \
 	word_list-c.o \
 	filter-c.o \
 	document_checker-c.o \
+	new_filter.o \
+	new_fmode.o \
 
-can_have_error-c.o:	can_have_error-c.cpp
-info-c.o:	info-c.cpp
-string_list-c.o:	string_list-c.cpp
-config-c.o:	config-c.cpp
-speller-c.o:	speller-c.cpp
-string_map-c.o:	string_map-c.cpp
-error-c.o:	error-c.cpp
-mutable_container-c.o:	mutable_container-c.cpp
-string_pair_enumeration-c.o:	string_pair_enumeration-c.cpp
-find_speller.o:	find_speller.cpp
-new_checker.o:	new_checker.cpp
-new_filter.o:	new_filter.cpp
-new_config.o:	new_config.cpp
-string_enumeration-c.o:	string_enumeration-c.cpp
-word_list-c.o:	word_list-c.cpp
 filter-c.o:	filter-c.cpp
+word_list-c.o:	word_list-c.cpp
+info-c.o:	info-c.cpp
+mutable_container-c.o:	mutable_container-c.cpp
+error-c.o:	error-c.cpp
 document_checker-c.o:	document_checker-c.cpp
+string_map-c.o:	string_map-c.cpp
+new_config.o:	new_config.cpp
+config-c.o:	config-c.cpp
+string_enumeration-c.o:	string_enumeration-c.cpp
+can_have_error-c.o:	can_have_error-c.cpp
+new_filter.o:	new_filter.cpp
+new_fmode.o:	new_fmode.cpp
+string_list-c.o:	string_list-c.cpp
+find_speller.o:	find_speller.cpp
+speller-c.o:	speller-c.cpp
+string_pair_enumeration-c.o:	string_pair_enumeration-c.cpp
+new_checker.o:	new_checker.cpp
+
+static_optfiles = ${top_srcdir}/modules/filter/url-filter.info
+
+### Add the .info file your filter comes with
+optfiles = \
+  ${top_srcdir}/modules/filter/email-filter.info\
+  ${top_srcdir}/modules/filter/tex-filter.info\
+  ${top_srcdir}/modules/filter/sgml-filter.info\
+  ${top_srcdir}/modules/filter/html-filter.info\
+  ${top_srcdir}/modules/filter/context-filter.info\
+  ${top_srcdir}/modules/filter/nroff-filter.info\
+  ${top_srcdir}/modules/filter/texinfo-filter.info
+
+static_optfiles += ${optfiles}
+
+# settings.h added as a dependency so it will get recreated if
+#   the COMPILE_IN_FILTERS option changes
+gen/static_filters.src.cpp: ${static_optfiles} ${top_srcdir}/gen/mk-static-filter.pl
+	perl ${top_srcdir}/gen/mk-static-filter.pl ${static_optfiles}
+
+${top_srcdir}/lib/new_filter.cpp: gen/static_filters.src.cpp
+
 
 aspell_dll: $(ASPELL_DLL_NAME)
 $(ASPELL_DLL_NAME): $(aspell_dll_OBJECTS)
-	$(CC) $(FLAGS) \
+	$(CXX) $(FLAGS) \
 	-shared \
 	$(aspell_dll_LDFLAGS) \
 	$+ \
@@ -375,7 +404,8 @@ aspell_dll_clean:
 	-rm $(aspell_dll_OBJECTS) \
 	$(ASPELL_DLL_NAME) \
 	$(ASPELL_DLL_LIB_NAME) \
-	$(ASPELL_DLL_DEF_NAME)
+	$(ASPELL_DLL_DEF_NAME) \
+	${top_srcdir}/gen/static_filters.src.cpp
 
 ################################################################################
 # {{{1	pspell-dll
@@ -395,7 +425,7 @@ dummy.o:	dummy.cpp
 
 pspell_dll: $(PSPELL_DLL_NAME)
 $(PSPELL_DLL_NAME): $(pspell_dll_OBJECTS)
-	$(CC) $(FLAGS) \
+	$(CXX) $(FLAGS) \
 	-shared \
 	$(pspell_dll_LDFLAGS) \
 	$+ \
@@ -426,7 +456,7 @@ checker_string.o:	checker_string.cpp
 
 aspell_exe: $(ASPELL_EXE_NAME)
 $(ASPELL_EXE_NAME): $(aspell_exe_OBJECTS)
-	$(CC) $(FLAGS) \
+	$(CXX) $(FLAGS) \
 	$+ \
 	$(aspell_exe_EXTRALIBS) \
 	$(CURSES_LIB) \
@@ -446,7 +476,7 @@ compress.o:	compress.c
 
 word_list_compress_exe: $(WORD_LIST_COMPRESS_EXE_NAME)
 $(WORD_LIST_COMPRESS_EXE_NAME): $(word_list_compress_OBJECTS)
-	$(CC) $(FLAGS) \
+	$(CXX) $(FLAGS) \
 	$+ \
 	$(LIBS) -o $@
 word_list_compress_clean:
@@ -492,15 +522,16 @@ regfile_clean:
 	-rm $(REGFILE_NAME)
 install: regfile
 	-mkdir $(installdir)
-	-mkdir $(installdir)/$(pkglibdir)
-	-mkdir $(installdir)/$(pkgdatadir)
+	-mkdir $(pkglibdir)
+	-mkdir $(pkgdatadir)
 	-cp  $(WORD_LIST_COMPRESS_EXE_NAME) \
 	    $(ASPELL_EXE_NAME) \
 	    $(PSPELL_DLL_NAME) \
 	    $(ASPELL_DLL_NAME) \
 	    $(installdir)
-	-cp $(top_srcdir)/data/*.dat $(installdir)/$(pkgdatadir)
-	-cp $(top_srcdir)/data/*.kbd $(installdir)/$(pkgdatadir)
+	-cp $(top_srcdir)/data/*.cmap $(pkgdatadir)
+	-cp $(top_srcdir)/data/*.cset $(pkgdatadir)
+	-cp $(top_srcdir)/data/*.kbd $(pkgdatadir)
 	-cp $(REGFILE_NAME) $(installdir)
 	
 

--- a/win32/settings.h
+++ b/win32/settings.h
@@ -90,3 +90,5 @@
 
 /* Version number of package */
 #define VERSION "0.50.3"
+
+#define C_EXPORT extern "C"

--- a/win32/static_filters.src.cpp
+++ b/win32/static_filters.src.cpp
@@ -1,0 +1,216 @@
+/*File generated during static filter build
+  Automatically generated file
+*/
+
+  extern "C" IndividualFilter * new_aspell_context_filter();
+
+  extern "C" IndividualFilter * new_aspell_texinfo_filter();
+
+  extern "C" IndividualFilter * new_aspell_sgml_decoder();
+
+  extern "C" IndividualFilter * new_aspell_sgml_filter();
+
+  extern "C" IndividualFilter * new_aspell_tex_filter();
+
+  extern "C" IndividualFilter * new_aspell_url_filter();
+
+  extern "C" IndividualFilter * new_aspell_nroff_filter();
+
+  extern "C" IndividualFilter * new_aspell_email_filter();
+
+  extern "C" IndividualFilter * new_aspell_html_decoder();
+
+  extern "C" IndividualFilter * new_aspell_html_filter();
+
+  static FilterEntry standard_filters[] = {
+    {"context",0,new_aspell_context_filter,0},
+    {"texinfo",0,new_aspell_texinfo_filter,0},
+    {"sgml",new_aspell_sgml_decoder,new_aspell_sgml_filter,0},
+    {"tex",0,new_aspell_tex_filter,0},
+    {"url",0,new_aspell_url_filter,0},
+    {"nroff",0,new_aspell_nroff_filter,0},
+    {"email",0,new_aspell_email_filter,0},
+    {"html",new_aspell_html_decoder,new_aspell_html_filter,0}
+  };
+
+  const unsigned int standard_filters_size = sizeof(standard_filters)/sizeof(FilterEntry);
+
+  static KeyInfo context_options[] = {
+    {
+      "f-context-visible-first",
+      KeyInfoBool,
+      "false",
+      "swaps visible and invisible text"
+    },
+    {
+      "f-context-delimiters",
+      KeyInfoList,
+      "\" \":/* */:// 0",
+      "context delimiters (separated by spaces)"
+    }
+  };
+
+  const KeyInfo * context_options_begin = context_options;
+
+  const KeyInfo * context_options_end = context_options+sizeof(context_options)/sizeof(KeyInfo);
+
+  static KeyInfo texinfo_options[] = {
+    {
+      "f-texinfo-ignore-env",
+      KeyInfoList,
+      "example:smallexample:verbatim:lisp:smalllisp:small:display:snalldisplay:format:smallformat",
+      "Texinfo environments to ignore"
+    },
+    {
+      "f-texinfo-ignore",
+      KeyInfoList,
+      "setfilename:syncodeindex:documentencoding:vskip:code:kbd:key:samp:verb:var:env:file:command:option:url:uref:email:verbatiminclude:xref:ref:pxref:inforef:c",
+      "Texinfo commands to ignore the parameters of"
+    }
+  };
+
+  const KeyInfo * texinfo_options_begin = texinfo_options;
+
+  const KeyInfo * texinfo_options_end = texinfo_options+sizeof(texinfo_options)/sizeof(KeyInfo);
+
+  static KeyInfo sgml_options[] = {
+    {
+      "f-sgml-skip",
+      KeyInfoList,
+      "",
+      "SGML tags to always skip the contents of"
+    },
+    {
+      "f-sgml-check",
+      KeyInfoList,
+      "",
+      "SGML attributes to always check"
+    }
+  };
+
+  const KeyInfo * sgml_options_begin = sgml_options;
+
+  const KeyInfo * sgml_options_end = sgml_options+sizeof(sgml_options)/sizeof(KeyInfo);
+
+  static KeyInfo tex_options[] = {
+    {
+      "f-tex-command",
+      KeyInfoList,
+      "addtocounter pp:addtolength pp:alpha p:arabic p:fnsymbol p:roman p:stepcounter p:setcounter pp:usecounter p:value p:newcounter po:refstepcounter p:label p:pageref p:ref p:newcommand poOP:renewcommand poOP:newenvironment poOPP:renewenvironment poOPP:newtheorem poPo:newfont pp:documentclass op:usepackage op:begin po:end p:setlength pp:addtolength pp:settowidth pp:settodepth pp:settoheight pp:enlargethispage p:hyphenation p:pagenumbering p:pagestyle p:addvspace p:framebox ooP:hspace p:vspace p:makebox ooP:parbox ooopP:raisebox pooP:rule opp:sbox pO:savebox pooP:usebox p:include p:includeonly p:input p:addcontentsline ppP:addtocontents pP:fontencoding p:fontfamily p:fontseries p:fontshape p:fontsize pp:usefont pppp:documentstyle op:cite p:nocite p:psfig p:selectlanguage p:includegraphics op:bibitem op:geometry p",
+      "TeX commands"
+    },
+    {
+      "f-tex-check-comments",
+      KeyInfoBool,
+      "false",
+      "check TeX comments"
+    }
+  };
+
+  const KeyInfo * tex_options_begin = tex_options;
+
+  const KeyInfo * tex_options_end = tex_options+sizeof(tex_options)/sizeof(KeyInfo);
+
+  static KeyInfo url_options[] = {0
+
+  };
+
+  const KeyInfo * url_options_begin = url_options;
+
+  const KeyInfo * url_options_end = url_options;//+sizeof(url_options)/sizeof(KeyInfo);
+
+  static KeyInfo nroff_options[] = {0
+
+  };
+
+  const KeyInfo * nroff_options_begin = nroff_options;
+
+  const KeyInfo * nroff_options_end = nroff_options;//+sizeof(nroff_options)/sizeof(KeyInfo);
+
+  static KeyInfo email_options[] = {
+    {
+      "f-email-margin",
+      KeyInfoInt,
+      "10",
+      "num chars that can appear before the quote char"
+    },
+    {
+      "f-email-quote",
+      KeyInfoList,
+      ">:|",
+      "email quote characters"
+    }
+  };
+
+  const KeyInfo * email_options_begin = email_options;
+
+  const KeyInfo * email_options_end = email_options+sizeof(email_options)/sizeof(KeyInfo);
+
+  static KeyInfo html_options[] = {
+    {
+      "f-html-skip",
+      KeyInfoList,
+      "script:style",
+      "HTML tags to always skip the contents of"
+    },
+    {
+      "f-html-check",
+      KeyInfoList,
+      "alt",
+      "HTML attributes to always check"
+    }
+  };
+
+  const KeyInfo * html_options_begin = html_options;
+
+  const KeyInfo * html_options_end = html_options+sizeof(html_options)/sizeof(KeyInfo);
+
+
+  static ConfigModule filter_modules[] = {
+    {
+      "context",0,
+      "experimental filter for hiding delimited contexts",
+      context_options_begin,context_options_end
+    },
+    {
+      "texinfo",0,
+      "filter for dealing with Texinfo documents",
+      texinfo_options_begin,texinfo_options_end
+    },
+    {
+      "sgml",0,
+      "filter for dealing with generic SGML/XML documents",
+      sgml_options_begin,sgml_options_end
+    },
+    {
+      "tex",0,
+      "filter for dealing with TeX/LaTeX documents",
+      tex_options_begin,tex_options_end
+    },
+    {
+      "url",0,
+      "filter to skip URL like constructs",
+      url_options_begin,url_options_end
+    },
+    {
+      "nroff",0,
+      "filter for dealing with Nroff documents",
+      nroff_options_begin,nroff_options_end
+    },
+    {
+      "email",0,
+      "filter for skipping quoted text in email messages",
+      email_options_begin,email_options_end
+    },
+    {
+      "html",0,
+      "filter for dealing with HTML documents",
+      html_options_begin,html_options_end
+    }
+  };
+
+  const ConfigModule * filter_modules_begin = filter_modules;
+
+  const ConfigModule * filter_modules_end = filter_modules+sizeof(filter_modules)/sizeof(ConfigModule);
+
+  const size_t filter_modules_size = sizeof(filter_modules);


### PR DESCRIPTION
, see https://ci.appveyor.com/project/chcg/aspell/build/0.60.6.1.37

Mingw dlls are dynamically linked, so there exists some additional dependencies. This could be reduced to just libgcc_s_xxx.dll by replacing

LIBS=$(GCC2LIBS)

with

LIBS= -static-libstdc++ -Wl,-Bstatic -lstdc++ -lpthread -Wl,-Bdynamic $(GCC2LIBS)

- Some files are taken from #415.
- makefile changes are taking over the file order from Makefile.am
- perl script mk-static-filter.pl to create static_filters.src.cpp still has a yet unresolved problem therefore win32\static_filters.src.cpp was added


