### PR TITLE
Do not call back() on an empty vector

### DIFF
--- a/common/vector.hpp
+++ b/common/vector.hpp
@@ -36,13 +36,13 @@ namespace acommon
     }
     T * data() {return &*this->begin();}
     T * data(int pos) {return &*this->begin() + pos;}
-    T * data_end() {return &this->back()+1;}
+    T * data_end() {return this->empty() ? &*this->begin() : &this->back()+1;}
 
     T * pbegin() {return &*this->begin();}
-    T * pend()   {return &this->back()+1;}
+    T * pend()   {return this->empty() ? &*this->begin() : &this->back()+1;}
 
     const T * pbegin() const {return &*this->begin();}
-    const T * pend()   const {return &this->back()+1;}
+    const T * pend()   const {return this->empty() ? &*this->begin() : &this->back()+1;}
 
     template <typename U>
     U * datap() { 


### PR DESCRIPTION
Calling `std::vector::back()` on an empty container is undefined.
Avoid doing that, simply return pointer to the beginning in case the vector is empty.

This is needed to prevent assertion failure when aspell is compiled with GCC 8.