### PR TITLE
Markdown filter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,6 +94,22 @@ jobs:
     - run: CXX=clang++-8 CC=clang-8 ./sanity-check.sh
     - run: ./config-opt && make -C build -j2
 
+  tests:
+    working_directory: ~/GNUAspell/aspell
+    parallelism: 1
+    docker:
+    - image: circleci/buildpack-deps:19.04
+    steps:
+    # Machine Setup
+    - checkout
+    #
+    - run: sudo apt-get -y update
+    - run: sudo apt-get -y install make autopoint texinfo libtool intltool bzip2 gettext libipc-system-simple-perl
+    - run: sudo apt-get -y purge aspell
+    #
+    - run: ./autogen
+    - run: make -j2 -C test
+
 workflows:
   version: 2
   sanity_check:
@@ -101,3 +117,6 @@ workflows:
       - build_jessie
       - build_18_04
       - build_19_04
+  tests:
+    jobs:
+      - tests

--- a/Makefile.am
+++ b/Makefile.am
@@ -166,6 +166,7 @@ optfiles = \
   modules/filter/email-filter.info\
   modules/filter/tex-filter.info\
   modules/filter/sgml-filter.info\
+  modules/filter/markdown-filter.info\
   modules/filter/html-filter.info\
   modules/filter/context-filter.info\
   modules/filter/nroff-filter.info\
@@ -175,6 +176,7 @@ optfiles = \
 fltfiles = \
   modules/filter/modes/html.amf \
   modules/filter/modes/sgml.amf \
+  modules/filter/modes/markdown.amf \
   modules/filter/modes/tex.amf \
   modules/filter/modes/email.amf \
   modules/filter/modes/ccpp.amf \
@@ -196,6 +198,7 @@ libaspell_la_SOURCES +=\
   modules/filter/email.cpp\
   modules/filter/tex.cpp\
   modules/filter/sgml.cpp\
+  modules/filter/markdown.cpp\
   modules/filter/context.cpp\
   modules/filter/nroff.cpp\
   modules/filter/texinfo.cpp
@@ -208,7 +211,7 @@ filter_ldflags = -module -avoid-version
 ### Add name of filter library containing your filter. Name always
 ### must look like lib<filtername>-filter.la see development manual
 filter_LTLIBRARIES = email-filter.la tex-filter.la\
-	             sgml-filter.la context-filter.la\
+	             sgml-filter.la markdown-filter.la context-filter.la\
                      nroff-filter.la texinfo-filter.la
 
 email_filter_la_SOURCES = modules/filter/email.cpp
@@ -222,6 +225,10 @@ tex_filter_la_LDFLAGS  = ${filter_ldflags}
 sgml_filter_la_SOURCES  = modules/filter/sgml.cpp
 sgml_filter_la_LIBADD = libaspell.la
 sgml_filter_la_LDFLAGS  = ${filter_ldflags}
+
+markdown_filter_la_SOURCES  = modules/filter/markdown.cpp
+markdown_filter_la_LIBADD = libaspell.la
+markdown_filter_la_LDFLAGS  = ${filter_ldflags}
 
 context_filter_la_SOURCES  = modules/filter/context.cpp
 context_filter_la_LIBADD = libaspell.la

--- a/auto/mk-src.in
+++ b/auto/mk-src.in
@@ -842,8 +842,11 @@ class: document checker
 	method: process
 
 		desc => Process a string.
-			The string passed in should only be split on
-			white space characters.  Furthermore, between
+			The document is expected to be passed in one or more
+			lines at a time.  Splitting the document on
+			white space characters instead of new lines is
+			permissible but some filters which are line based
+			may give incorrect results.  Furthermore, between
 			calls to reset, each string should be passed
 			in exactly once and in the order they appeared
 			in the document.  Passing in strings out of

--- a/config-debug
+++ b/config-debug
@@ -4,4 +4,4 @@ mkdir -p build
 cd build
 ../configure --enable-maintainer-mode \
   --disable-shared --disable-pspell-compatibility\
-  --prefix="`pwd`/../inst" CFLAGS='-g -Wall' CXXFLAGS='-g -Wall' "$@"
+  --prefix="`pwd`/../inst" CFLAGS='-g -Wall -Wno-unused' CXXFLAGS='-g -Wall -Wno-unused' "$@"

--- a/manual/aspell.texi
+++ b/manual/aspell.texi
@@ -1355,6 +1355,55 @@ The @option{html} filter is like the SGML Filter Mode but specialized for
 HTML.  By default, 'script' and 'style' are members of the skip list in
 HTML mode.
 
+@subsubsection Markdown Filter
+
+The @option{markdown} filter/mode skips over code and links in Markdown
+documents.  The mode also handles HTML via the @option{html} filter
+which runs after the Markdown filer.
+
+Properly parsing Markdown requires reading the entire document in at
+once, which doesn't fit well into the existing filter framework so the
+filter parses the document a line at a time and makes a best guess
+when a line ends without enough information to correctly parse a a
+tag.  For example in the following:
+@example
+`This looks like inline code
+
+But it's not, becuase the of the blank line.
+@end example
+the first line will be incorrectly skipped.
+
+It supports the following two options that may be useful:
+
+@table @b
+
+@item markdown-multiline-tags
+Enables or disables support for HTML tags that might span multiple
+lines (outside of HTML blocks).  Enabled by default (to disable from
+the command line use @samp{--dont-markdown-multiline-tags}).
+
+@item markdown-skip-ref-labels
+Boolean option the controls if ref lables are skipped.  For when this
+option is enabled @samp{[ref]} will be skipped over in:
+@example
+[link][ref]
+
+[ref]: #c2 "Chapter 2"
+@end example
+Enabled by default (to disable from
+the command line use @samp{--dont-markdown-skip-ref-labels}).
+
+@end table
+
+The Markdown filter also supports the @option{markdown-raw-start-tags}
+and @option{markdown-block-start-tags} list options.  These options
+are a list of HTML tags that start an HTML block.  If the block starts
+with a tag listed in @option{markdown-raw-start-tags} then the block
+ends with the corresponding closing tag.  If the block starts with a
+tag listed in @option{markdown-block-start-tags} then the block ends
+with a blank line.  The defaults for these two options are taken from
+the CommonMark spec (version 0.29, 2019-04-06).
+
 @subsubsection @TeX{}/LaTeX Filter
 
 The @option{tex} (all lowercase) filter mode skips over @TeX{}
@@ -4272,9 +4321,17 @@ a C++ program.
 @heading Changes from 0.60.7 to 0.68.8 (???)
 @itemize @bullet
 @item
+Add Markdown filter.
+@item
 Implement @code{aspell filter} command.
 @item
 Remove unused @option{sug-edit-dist} option.
+@item
+In order to work with the new Markdown filter
+@code{AspellDocumentChecker} now expects the document a line at a
+time.  If the document is split on white space characters instead,
+nothing will break, but new filters such as the Markdown filter may
+give incorrect results.
 @end itemize
 
 @heading Changes from 0.60.6.1 to 0.60.7 (July 29, 2019)

--- a/manual/aspell.texi
+++ b/manual/aspell.texi
@@ -4272,6 +4272,8 @@ a C++ program.
 @heading Changes from 0.60.7 to 0.68.8 (???)
 @itemize @bullet
 @item
+Implement @code{aspell filter} command.
+@item
 Remove unused @option{sug-edit-dist} option.
 @end itemize
 

--- a/modules/filter/markdown-filter.info
+++ b/modules/filter/markdown-filter.info
@@ -1,0 +1,91 @@
+# SGML filter option file
+
+LIB-FILE markdown-filter
+
+#This Filter is usable with the following version(s) of Aspell
+ASPELL >=0.60
+
+DESCRIPTION filter for Markdown/CommonMark documents
+
+STATIC filter
+
+OPTION multiline-tags
+TYPE bool
+DESCRIPTION support tags that span multiple lines outside of HTML blocks
+DEFAULT true
+ENDOPTION
+
+OPTION raw-start-tags
+TYPE list
+DESCRIPTION html tags that start a HTML block that allows blank lines
+DEFAULT script
+DEFAULT pre
+DEFAULT style
+ENDOPTION
+
+OPTION block-start-tags
+TYPE list
+DESCRIPTION html tags that start a HTML block that end with a blank line
+DEFAULT address
+DEFAULT article
+DEFAULT aside
+DEFAULT base
+DEFAULT basefont
+DEFAULT blockquote
+DEFAULT body
+DEFAULT caption
+DEFAULT center
+DEFAULT col
+DEFAULT colgroup
+DEFAULT dd
+DEFAULT details
+DEFAULT dialog
+DEFAULT dir
+DEFAULT div
+DEFAULT dl
+DEFAULT dt
+DEFAULT fieldset
+DEFAULT figcaption
+DEFAULT figure
+DEFAULT footer
+DEFAULT form
+DEFAULT frame
+DEFAULT frameset
+DEFAULT h1
+DEFAULT h2
+DEFAULT h3
+DEFAULT h4
+DEFAULT h5
+DEFAULT h6
+DEFAULT head
+DEFAULT header
+DEFAULT hr
+DEFAULT html
+DEFAULT iframe
+DEFAULT legend
+DEFAULT li
+DEFAULT link
+DEFAULT main
+DEFAULT menu
+DEFAULT menuitem
+DEFAULT nav
+DEFAULT noframes
+DEFAULT ol
+DEFAULT optgroup
+DEFAULT option
+DEFAULT p
+DEFAULT param
+DEFAULT section
+DEFAULT source
+DEFAULT summary
+DEFAULT table
+DEFAULT tbody
+DEFAULT td
+DEFAULT tfoot
+DEFAULT th
+DEFAULT thead
+DEFAULT title
+DEFAULT tr
+DEFAULT track
+DEFAULT ul
+ENDOPTION

--- a/modules/filter/markdown-filter.info
+++ b/modules/filter/markdown-filter.info
@@ -9,6 +9,12 @@ DESCRIPTION filter for Markdown/CommonMark documents
 
 STATIC filter
 
+OPTION skip-ref-labels
+TYPE bool
+DESCRIPTION skip link labels in link reference definitions
+DEFAULT true
+ENDOPTION
+
 OPTION multiline-tags
 TYPE bool
 DESCRIPTION support tags that span multiple lines outside of HTML blocks

--- a/modules/filter/markdown.cpp
+++ b/modules/filter/markdown.cpp
@@ -1,0 +1,791 @@
+#include "settings.h"
+
+#include "config.hpp"
+#include "indiv_filter.hpp"
+#include "iostream.hpp"
+#include "string_map.hpp"
+#include "asc_ctype.hpp"
+
+#include <typeinfo>
+
+//#define DEBUG_FILTER
+
+namespace {
+
+using namespace acommon;
+
+struct Iterator;
+
+struct Block {
+  Block * next;
+  Block() : next() {}
+  enum KeepOpenState {NEVER, MAYBE, YES};
+  virtual KeepOpenState proc_line(Iterator &) = 0;
+  virtual void dump() const = 0;
+  virtual bool leaf() const = 0;
+  virtual ~Block() {}
+};
+
+struct DocRoot : Block {
+  KeepOpenState proc_line(Iterator &) {return YES;}
+  void dump() const {CERR.printf("DocRoot\n");}
+  bool leaf() const {return false;}
+};
+
+struct MultilineInlineState;
+
+class MarkdownFilter : public IndividualFilter {
+public:
+  MarkdownFilter() : root(), back(&root), prev_blank(true), inline_state() {
+    name_ = "markdown-filter";
+    order_num_ = 0.30; // need to be before SGML filter
+  }
+  PosibErr<bool> setup(Config *);
+  void reset();
+  ~MarkdownFilter();
+
+  void process(FilterChar * & start, FilterChar * & stop);
+
+private:
+  void dump() {
+    CERR.printf(">>>blocks\n");
+    for (Block * cur = &root; cur; cur = cur->next) {
+      cur->dump();
+    }
+    CERR.printf("<<<blocks\n");
+  }
+
+  StringMap block_start_tags;
+  StringMap raw_start_tags;
+  
+  DocRoot root;
+  Block * back;
+  bool prev_blank;
+  MultilineInlineState * inline_state;
+ 
+  void kill(Block * blk) {
+    Block * cur = &root;
+    while (cur->next && cur->next != blk)
+      cur = cur->next;
+    back = cur;
+    Block * next = cur->next;
+    cur->next = NULL;
+    cur = next;
+    while (cur) {
+      next = cur->next;
+      delete cur;
+      cur = next;
+    }
+  }
+
+  void add(Block * blk) {
+    back->next = blk;
+    back = blk;
+  }
+
+  Block * start_block(Iterator & itr);
+};
+
+//
+// Iterator class
+//
+
+inline void blank(FilterChar & chr) {
+  if (!asc_isspace(chr))
+    chr = ' ';
+}
+
+struct Iterator {
+  FilterChar * i;
+  FilterChar * end;
+  int line_pos;
+  int indent;
+  Iterator(FilterChar * start, FilterChar * stop)
+    : i(start), end(stop), line_pos(), indent() {}
+  void * pos() {return i;}
+  unsigned int operator[](unsigned x) const {
+    if (i + x >= end) return '\0';
+    if (*i == '\r' || *i == '\n') return '\0';
+    else return i[x];
+  }
+  unsigned int operator *() const {return operator[](0); }
+  bool eol() const {return operator*() == '\0';}
+  bool at_end() const {return i >= end;}
+  int width() const {
+    if (i == end) return 0;
+    if (*i == '\t') return 4  - (line_pos % 4);
+    return 1;
+  }
+  bool eq(const char * str) {
+    int i = 0;
+    while (str[i] != '\0' && operator[](i) == str[i])
+      ++i;
+    return str[i] == '\0';
+  }
+  void inc() {
+    indent = 0;
+    if (i == end) return;
+    line_pos += width();
+    ++i;
+  }
+  void adv(int width = 1) {
+    for (; width > 0; --width)
+      inc();
+    eat_space();
+  }
+  void blank_adv(int width = 1) {
+    for (; !eol() && width > 0; --width) {
+      blank(*i);
+      inc();
+    }
+    eat_space();
+  }
+  void blank_rest() {
+    while (!eol()) {
+      blank(*i);
+      inc();
+    }
+  }
+  int eat_space();
+  void next_line();
+};
+
+int Iterator::eat_space() {
+  indent = 0;
+  while (!eol()) {
+    if (*i == ' ') {
+      ++i;
+      indent++;
+      line_pos++;
+    } else if (*i == '\t') {
+      int w = width();
+      ++i;
+      indent += w;
+      line_pos += w;
+    } else {
+      break;
+    }
+  }
+  return indent;
+}
+
+void Iterator::next_line() {
+  while (!eol())
+    inc();
+  if (!at_end() && *i == '\n') {
+    ++i;
+    if (!at_end() && *i == '\r') {
+      ++i;
+    }
+  } else if (!at_end() && *i == '\r') {
+    ++i;
+  }
+  line_pos = 0;
+}
+
+//
+// Markdown blocks and inlines
+// 
+
+struct BlockQuote : Block {
+  static BlockQuote * start_block(Iterator & itr) {
+    if (*itr == '>') {
+      itr.blank_adv();
+      return new BlockQuote();
+    }
+    return NULL;
+  }
+  KeepOpenState proc_line(Iterator & itr) {
+    if (*itr == '>') {
+      itr.blank_adv();
+      return YES;
+    } else if (itr.eol()) {
+      return NEVER;
+    }
+    return MAYBE;
+  }
+  void dump() const {CERR.printf("BlockQuote\n");}
+  bool leaf() const {return false;}
+};
+
+struct ListItem : Block {
+  char marker; // '-' '+' or '*' for bullet lists; '.' or ')' for ordered lists
+  int indent; // indention required in order to be considered part of
+              // the same list item
+  ListItem(char m, int i)
+    : marker(m), indent(i) {}
+  static ListItem * start_block(Iterator & itr) {
+    char marker = '\0';
+    int width = 0;
+    if (*itr == '-' || *itr == '+' || *itr == '*') {
+      marker = *itr;
+      width = 1;
+    } else if (asc_isdigit(*itr)) {
+      width = 1;
+      while (asc_isdigit(itr[width]))
+        width += 1;
+      if (itr[width] == '.' || itr[width] == ')') {
+        width += 1;
+        marker = *itr;
+      }
+    }
+    if (marker != '\0') {
+      itr.adv(width);
+      if (itr.indent <= 4) {
+        int indent = width + itr.indent;
+        itr.indent = 0;
+        return new ListItem(marker, indent);
+      } else {
+        int indent = 1 + itr.indent;
+        itr.indent -= 1;
+        return new ListItem(marker, indent);
+      }
+    }
+    return NULL;
+  }
+  KeepOpenState proc_line(Iterator & itr) {
+    if (!itr.eol() && itr.indent >= indent) {
+      itr.indent -= indent;
+      return YES;
+    }
+    return MAYBE;
+  }
+  void dump() const {CERR.printf("ListItem: '%c' %d\n", marker, indent);}
+  bool leaf() const {return false;}
+};
+
+struct IndentedCodeBlock : Block {
+  static IndentedCodeBlock * start_block(bool prev_blank, Iterator & itr) {
+    if (prev_blank && !itr.eol() && itr.indent >= 4) {
+      itr.blank_rest();
+      return new IndentedCodeBlock();
+    }
+    return NULL;
+  }
+  KeepOpenState proc_line(Iterator & itr) {
+    if (itr.indent >= 4) {
+      itr.blank_rest();
+      return YES;
+    } else if (itr.eol()) {
+      return YES;
+    }
+    return NEVER;
+  }
+  void dump() const {CERR.printf("IndentedCodeBlock\n");}
+  bool leaf() const {return true;}
+};
+
+struct FencedCodeBlock : Block {
+  char delem;
+  int  delem_len;
+  FencedCodeBlock(char d, int l) : delem(d), delem_len(l) {}
+  static FencedCodeBlock * start_block(Iterator & itr) {
+    if (*itr == '`' || *itr == '~') {
+      char delem = *itr;
+      int i = 1;
+      while (itr[i] == delem)
+        ++i;
+      if (i < 3) return NULL;
+      itr.blank_adv(i);
+      itr.blank_rest(); // blank info string
+      return new FencedCodeBlock(delem, i);
+    }
+    return NULL;
+  }
+  KeepOpenState proc_line(Iterator & itr) {
+    if (*itr == '`' || *itr == '~') {
+      char delem = *itr;
+      int i = 1;
+      while (itr[i] == delem)
+        ++i;
+      itr.blank_adv(i);
+      if (i >= delem_len && itr.eol()) {
+        return NEVER;
+      }
+    }
+    itr.blank_rest();
+    return YES;
+  }
+  bool blank_rest() const {
+    return true;
+  }
+  void dump() const {CERR.printf("FencedCodeBlock: `%c` %d\n", delem, delem_len);}
+  bool leaf() const {return true;}
+};
+
+struct SingleLineBlock : Block {
+  static SingleLineBlock * start_block(Iterator & itr) {
+    unsigned int chr = *itr;
+    switch (chr) {
+    case '-': case '_': case '*': {
+      Iterator i = itr;
+      i.adv();
+      while (*i == *itr)
+        i.adv();
+      if (i.eol()) {
+        itr = i; 
+        return new SingleLineBlock();
+      }
+      if (chr != '-') // fall though on '-' case
+        break;
+    }
+    case '=': {
+      Iterator i = itr;
+      i.inc();
+      while (*i == *itr)
+        i.inc();
+      i.eat_space();
+      if (i.eol()) {
+        itr = i;
+        return new SingleLineBlock();
+      }
+      break;
+    }
+    case '#':
+      return new SingleLineBlock();
+      break;
+    case '[': {
+      Iterator i = itr;
+      i.adv();
+      if (*i == ']') break;
+      while (*i != ']') {
+        i.adv();
+      }
+      i.inc();
+      if (*i != ':') break;
+      return new SingleLineBlock();
+    }
+    }
+    return NULL;
+  }
+  KeepOpenState proc_line(Iterator & itr) {return NEVER;}
+  bool leaf() const {return true;}
+  void dump() const {CERR.printf("SingleLineBlock\n");}
+};
+
+struct MultilineInline {
+  virtual MultilineInline * close(Iterator & itr) = 0;
+  virtual ~MultilineInline() {}
+};
+
+struct InlineCode : MultilineInline {
+  int marker_len;
+  MultilineInline * open(Iterator & itr) {
+    if (*itr == '`') {
+      int i = 1;
+      while (itr[i] == '`')
+        ++i;
+      itr.blank_adv(i);
+      marker_len = i;
+      return close(itr);
+    }
+    return NULL;
+  }
+  MultilineInline * close(Iterator & itr) {
+    while (!itr.eol()) {
+      if (*itr == '`') {
+        int i = 1;
+        while (i < marker_len && itr[i] == '`')
+          ++i;
+        if (i == marker_len) {
+          itr.blank_adv(i);
+          return NULL;
+        }
+      }
+      itr.blank_adv();
+    }
+    return this;
+  }
+};
+
+struct HtmlComment : MultilineInline {
+  MultilineInline * open(Iterator & itr) {
+    if (itr.eq("<!--")) {
+      itr.adv(4);
+      return close(itr);
+    }
+    return NULL;
+  }
+  MultilineInline * close(Iterator & itr) {
+    while (!itr.eol()) {
+      if (itr.eq("-->")) {
+        itr.adv(3);
+        return NULL;
+      }
+      itr.inc();
+    }
+    return this;
+  }
+};
+
+bool parse_tag_close(Iterator & itr) {
+  if (*itr == '>') {
+    itr.adv();
+    return true;
+  } else if (*itr == '/' && itr[1] == '>') {
+    itr.adv(2);
+    return true;
+  }
+  return false;
+}
+
+// note: does _not_ eat trialing whitespaceb
+bool parse_tag_name(Iterator & itr, String & tag) {
+  if (asc_isalpha(*itr)) {
+    tag += static_cast<char>(*itr);
+    itr.inc();
+    while (asc_isalpha(*itr) || asc_isdigit(*itr) || *itr == '-') {
+      tag += static_cast<char>(*itr);
+      itr.inc();
+    }
+    return true;
+  }
+  return false;
+}
+
+enum ParseTagState {
+  Invalid,Between,AfterName,AfterEq,InSingleQ,InDoubleQ,Valid
+};
+
+// note: does _not_ eat trialing whitespace
+ParseTagState parse_attribute(Iterator & itr, ParseTagState state) {
+  switch (state) {
+    // note: this switch is being used as a computed goto to make
+    //   restoring state straightforward without restructuring the code
+  case Between:
+    if (asc_isalpha(*itr) || *itr == '_' || *itr == ':') {
+      itr.inc();
+      while (asc_isalpha(*itr) || asc_isdigit(*itr)
+             || *itr == '_' || *itr == ':' || *itr == '.' || *itr == '-')
+        itr.inc();
+    case AfterName:
+      itr.eat_space();
+      if (itr.eol()) return AfterName;
+      if (*itr != '=') return Invalid;
+      state = AfterEq;
+      itr.inc();
+    case AfterEq:
+      itr.eat_space();
+      if (itr.eol()) return AfterEq;
+      if (*itr == '\'') {
+        itr.inc();
+      case InSingleQ:
+        while (!itr.eol() && *itr != '\'')
+          itr.inc();
+        if (itr.eol()) return InSingleQ;
+        if (*itr != '\'') return Invalid;
+        itr.inc();
+      } else if (*itr == '"') {
+        itr.inc();
+      case InDoubleQ:
+        while (!itr.eol() && *itr != '"')
+          itr.inc();
+        if (itr.eol()) return InDoubleQ;
+        if (*itr != '"') return Invalid;
+        itr.inc();
+      } else {
+        void * pos = itr.pos();
+        while (!itr.eol() && !asc_isspace(*itr)
+               && *itr != '"' && *itr != '\'' && *itr != '='
+               && *itr != '<' && *itr != '>' && *itr != '`')
+          itr.inc();
+        if (pos == itr.pos()) return Invalid;
+      }
+    }
+    return Between;
+  case Valid: case Invalid:
+    // should not happen
+    abort();
+  }
+}
+
+struct HtmlTag : MultilineInline {
+  HtmlTag(bool mlt) : multi_line_tags(mlt), start_pos(NULL), last(NULL,NULL) {}
+  void * start_pos; // used for caching
+  Iterator last;    // ditto
+  String name;
+  bool closing;
+  ParseTagState state;
+  bool multi_line_tags;
+  void reset() {
+    start_pos = NULL;
+    name.clear();
+    closing = false;
+    state = Invalid;
+  }
+  MultilineInline * open(const Iterator & itr0, Iterator & itr) {
+    if (itr.pos() == start_pos) {
+      itr = last;
+      if (state != Invalid && state != Valid)
+        return this;
+      return NULL;
+    }
+    reset();
+    start_pos = itr.pos();
+    if (*itr == '<') {
+      itr.inc();
+      if (*itr == '/') {
+        itr.inc();
+        closing = true;
+      }
+      if (!parse_tag_name(itr, name))
+        return invalid(itr0, itr);
+      state = Between;
+      if (itr.eol()) {
+        return incomplete(itr0, itr);
+      } else if (parse_tag_close(itr)) {
+        return valid(itr0, itr);
+      } else if (asc_isspace(*itr)) {
+        return close(itr0, itr);
+      } else {
+        return invalid(itr0, itr);
+      }
+    }
+    return invalid(itr0, itr);
+  }
+  MultilineInline * open(Iterator & itr) {
+    Iterator itr0 = itr;
+    return open(itr0, itr);
+  }
+  MultilineInline * close(const Iterator & itr0, Iterator & itr) {
+    while (!itr.eol()) {
+      if (state == Between) {
+        bool leading_space = asc_isspace(*itr);
+        if (leading_space)
+          itr.eat_space();
+        
+        if (parse_tag_close(itr))
+          return valid(itr0, itr);
+        
+        if (itr.line_pos != 0 && !leading_space)
+          return invalid(itr0, itr);
+      }
+
+      state = parse_attribute(itr, state);
+      if (state == Invalid)
+        return invalid(itr0, itr);
+    }
+    return incomplete(itr0, itr);
+  }
+  MultilineInline * close(Iterator & itr) {
+    Iterator itr0 = itr;
+    return close(itr0, itr);
+  }
+
+  MultilineInline * valid(const Iterator & itr0, Iterator & itr) {
+    state = Valid;
+    last = itr;
+    return NULL;
+  }
+  MultilineInline * invalid(const Iterator & itr0, Iterator & itr) {
+    state = Invalid;
+    itr = itr0;
+    last = itr;
+    return NULL;
+  }
+  MultilineInline * incomplete(const Iterator & itr0, Iterator & itr) {
+    last = itr;
+    if (multi_line_tags)
+      return this;
+    return invalid(itr0, itr);
+  }
+};
+
+struct HtmlBlock : Block {
+  HtmlBlock(Iterator & itr) {
+    proc_line(itr);
+  }
+  KeepOpenState proc_line(Iterator & itr) {
+    if (itr.eol()) return NEVER;
+    while (!itr.eol()) itr.inc();
+    return YES;
+  }
+  void dump() const {CERR.printf("HtmlBlock\n");}
+  bool leaf() const {return true;}
+};
+
+struct RawHtmlBlock : Block {
+  RawHtmlBlock(Iterator & itr, ParmStr tn) : done(false), tag(false), tag_name(tn) {
+    proc_line(itr);
+  }
+  bool done;
+  HtmlTag tag;
+  String tag_name;
+  KeepOpenState proc_line(Iterator & itr) {
+    tag.reset();
+    if (done) return NEVER;
+    while (!itr.eol()) {
+      tag.open(itr);
+      if (tag.state == Valid && tag.closing && tag.name == tag_name) {
+        done = true;
+        while (!itr.eol()) itr.inc();
+        return NEVER;
+      }
+      itr.adv();
+    }
+    return YES;
+  }
+  void dump() const {CERR.printf("RawHtmlBlock: %s\n", tag_name.c_str());}
+  bool leaf() const {return true;}
+};
+
+Block * start_html_block(Iterator & itr, HtmlTag & tag,
+                         const StringMap & start_tags,
+                         const StringMap & raw_tags) {
+  Iterator itr0 = itr;
+  tag.open(itr0, itr);
+  if (!tag.closing && raw_tags.have(tag.name))
+    return new RawHtmlBlock(itr,tag.name);
+  if ((tag.state == Valid && itr.eol())
+      || start_tags.have(tag.name)) {
+    return new HtmlBlock(itr);
+  }
+  itr = itr0;
+  return NULL;
+}
+
+struct MultilineInlineState {
+  MultilineInlineState(bool mlt) : ptr(), tag(mlt) {}
+  MultilineInline * ptr;
+  InlineCode inline_code;
+  HtmlComment comment;
+  HtmlTag tag;
+  void reset() {
+    tag.reset();
+  }
+};
+
+//
+// MarkdownFilter implementation
+//
+
+PosibErr<bool> MarkdownFilter::setup(Config * cfg) {
+  bool multiline_tags = cfg->retrieve_bool("f-markdown-multiline-tags");
+  delete inline_state;
+  inline_state = new MultilineInlineState(multiline_tags);
+  raw_start_tags.clear();
+  cfg->retrieve_list("f-markdown-raw-start-tags",  &raw_start_tags);
+  block_start_tags.clear();
+  cfg->retrieve_list("f-markdown-block-start-tags", &block_start_tags);
+
+  return true;
+}
+
+void MarkdownFilter::reset() {
+  kill(root.next);
+  prev_blank = true;
+  inline_state->reset();
+}
+
+
+MarkdownFilter::~MarkdownFilter() {
+  kill(root.next);
+  delete inline_state;
+}
+
+void MarkdownFilter::process(FilterChar * & start, FilterChar * & stop) {
+  inline_state->reset(); // to clear cached values
+  Iterator itr(start,stop);
+  bool blank_line = false;
+  while (!itr.at_end()) {
+    if (inline_state->ptr) {
+#ifdef DEBUG_FILTER
+      CERR.printf("*** continuing multi-line inline %s\n", typeid(*inline_state->ptr).name());
+#endif
+      inline_state->ptr = inline_state->ptr->close(itr);
+    } else {
+      itr.eat_space();
+      
+      Block * blk = &root;
+      Block::KeepOpenState keep_open;
+      for (; blk; blk = blk->next) {
+        keep_open = blk->proc_line(itr);
+        if (keep_open != Block::YES)
+          break;
+      }
+
+      blank_line = itr.eol();
+      Block * nblk = blank_line || (keep_open == Block::YES && back->leaf())
+        ? NULL
+        : start_block(itr);
+      
+      if (nblk || keep_open == Block::NEVER || (prev_blank && !blank_line)) {
+#ifdef DEBUG_FILTER
+        CERR.printf("*** kill\n");
+#endif
+        kill(blk);
+      } else {
+        for (; blk; blk = blk->next) {
+          keep_open = blk->proc_line(itr);
+          if (keep_open == Block::NEVER) {
+#ifdef DEBUG_FILTER
+            CERR.printf("***** kill\n");
+#endif          
+            kill(blk);
+            break;
+          }
+        }
+      }
+
+      if (nblk) {
+#ifdef DEBUG_FILTER
+        CERR.printf("*** new block\n");
+#endif
+        add(nblk);
+        prev_blank = true;
+      }
+
+      while (nblk && !nblk->leaf()) {
+        nblk = start_block(itr);
+        if (nblk) {
+#ifdef DEBUG_FILTER
+          CERR.printf("*** new block\n");
+#endif         
+          add(nblk);
+        }
+      }
+
+#ifdef DEBUG_FILTER
+      dump();
+#endif
+    }
+    // now process line, mainly blank inline code and handle html tags
+      
+    while (!itr.eol()) {
+      inline_state->ptr = inline_state->inline_code.open(itr);
+      if (inline_state->ptr) break;
+      inline_state->ptr = inline_state->comment.open(itr);
+      if (inline_state->ptr) break;
+      inline_state->ptr = inline_state->tag.open(itr);
+      if (inline_state->ptr) break;
+      if (*itr == '<' || *itr == '>')
+        itr.blank_adv();
+      else
+        itr.adv();
+    }
+
+    itr.next_line();
+
+    prev_blank = blank_line;
+  }
+}
+
+Block * MarkdownFilter::start_block(Iterator & itr) {
+  inline_state->tag.reset();
+  Block * nblk = NULL;
+  (nblk = IndentedCodeBlock::start_block(prev_blank, itr))
+    || (nblk = FencedCodeBlock::start_block(itr))
+    || (nblk = BlockQuote::start_block(itr))
+    || (nblk = ListItem::start_block(itr))
+    || (nblk = SingleLineBlock::start_block(itr))
+    || (nblk = start_html_block(itr, inline_state->tag, block_start_tags, raw_start_tags));
+  return nblk;
+}
+
+} // anon namespace
+
+C_EXPORT IndividualFilter * new_aspell_markdown_filter() 
+{
+  return new MarkdownFilter();
+}
+

--- a/modules/filter/modes/markdown.amf
+++ b/modules/filter/modes/markdown.amf
@@ -1,0 +1,14 @@
+# Markdown mode description file
+
+MODE markdown
+
+ASPELL >=0.60
+
+MAGIC /<noregex>/md/markdown/mdown
+
+DESCRIPTION mode for checking Markdown/CommonMark documents
+
+FILTER url
+FILTER markdown
+FILTER sgml
+

--- a/prog/aspell.cpp
+++ b/prog/aspell.cpp
@@ -2839,7 +2839,7 @@ static const char * usage_text[] =
   N_("<command> is one of:"),
   N_("  -?|usage         display a brief usage message"),
   N_("  help             display a detailed help message"),
-  N_("  -c|check <file>  to check a file"),
+  N_("  -c|check <file>  spellchecks a file"),
   N_("  -a|pipe          \"ispell -a\" compatibility mode"),
   N_("  [dump] config    dumps the current configuration to stdout"),
   N_("  config <key>     prints the current value of an option"),

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -3,4 +3,5 @@ inst/
 tmp/
 aspell6-en-2018.04.16-0/
 
+test-res
 aspell6-en-2018.04.16-0.tar.bz2

--- a/test/Makefile
+++ b/test/Makefile
@@ -4,15 +4,22 @@ export ASPELL = ${CURDIR}/inst/bin/aspell
 export PREZIP = ${CURDIR}/inst/bin/prezip-bin
 MAKE := ${MAKE} "CXXFLAGS=${CXXFLAGS}" "CFLAGS=${CFLAGS}"
 
-all:: prep sanity
+all:: prep sanity filter-test
+	cat test-res
 
 prep:: inst/bin/aspell inst/lib/aspell-0.60/en.multi tmp
+	rm -f test-res
 
 tmp:
 	mkdir tmp
 
 sanity:: prep
 	./sanity
+	echo "all ok (sanity)" >> test-res
+
+filter-test:: prep
+	./filter-test "${ASPELL}" < markdown.dat
+	echo "all ok (markdown filter-test)" >> test-res
 
 inst/bin/aspell: build/Makefile phony
 	$(MAKE) -C build install

--- a/test/filter-test
+++ b/test/filter-test
@@ -1,0 +1,94 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use autodie qw(:all);
+
+my $parms;
+my @tests;
+
+if (@ARGV != 1) {
+    die("usage $0 <aspell-binary>\n");
+}
+
+my $ASPELL=$ARGV[0];
+
+sub sys($) {
+    #print "@_\n";
+    system "@_";
+}
+
+my $passed = 0;
+my $failed = 0;
+my $skipped = 0;
+
+while (<STDIN>) {
+    next if /^\s+$/;
+    #print ">>$_";
+    if (/^-/) {
+        chomp;
+        $parms = $_;
+        next;
+    }
+    chomp;
+    my $desc = $_;
+    my $in = '';
+    my $out = '';
+    $_ = <STDIN>;
+    my $skip = 0;
+    if (/^\! (.+)/) {
+        die "Unknown directive: $1" unless $1 eq 'SKIP';
+        $skip = 1;
+        $_ = <STDIN>;
+    }
+    if (/^-/) {
+        my $sep = $_;
+        while (<STDIN>) {
+            #print ">$sep>$_";
+            last if $_ eq $sep;
+            $in .= $_;
+        }
+        while (<STDIN>) {
+            last if $_ eq $sep;
+            $out .= $_;
+        }
+    } else {
+        $in = $_;
+        $out = <STDIN>;
+    }
+    #print "$parms\n";
+    #print ">>>IN>>>\n";
+    #print $in;
+    #print ">>>OUT>>>\n";
+    #print $out;
+    #print "^^^^^^^^^\n";
+
+    if ($skip) {
+        $skipped++;
+        next;
+    }
+
+    open F, ">test-data.in";
+    print F $in;
+    open F, ">test-data.expect";
+    print F $out;
+    eval {
+        sys "$ASPELL filter --mode=none $parms < test-data.in > test-data.out";
+        sys "diff -u -Z test-data.expect test-data.out";
+    };
+    if ($@) {
+        $failed++;
+        print STDERR "FAILED: $desc: $@\n";
+    } else {
+        $passed++;
+        #print STDERR "passed: $desc\n";
+    }
+}
+
+if ($failed > 0) {
+    printf("FAILED %d/%d tests (%d skipped)\n", $failed, $failed + $passed, $skipped);
+    exit 1;
+} else {
+    printf("all ok (%d skipped)\n", $skipped);
+    exit 0;
+}

--- a/test/markdown.dat
+++ b/test/markdown.dat
@@ -1,0 +1,479 @@
+--add-filter=markdown
+
+Multiple inlines
+begin <tag> `code` <another>`code`<not a tag> end
+begin <tag>        <another>       not a tag  end
+
+Fenced code block
+---
+begin
+```
+ABC
+
+DEF
+```
+end
+---
+begin
+
+
+
+
+
+end
+---
+
+Indented code
+---
+begin
+
+    ABC
+
+    DEF
+
+end
+---
+begin
+
+
+
+
+
+end
+---
+
+Simple blockquote
+> quoted text
+  quoted text
+
+Multiline blockquote
+---
+> line a
+> line b
+---
+  line a
+  line b
+---
+
+
+Fenced code inside blockquote
+---
+> begin
+> ```
+> ABC
+>
+> DEF
+> ```
+> end
+---
+  begin
+
+
+
+
+
+  end
+---
+
+Indented code inside blockquote
+---
+> begin
+>
+>     ABC
+>
+>     DEF
+>
+> end
+---
+  begin
+
+
+
+
+
+  end
+---
+
+Indented text handling after block quote
+---
+> begin
+      Not code
+      Still not code
+
+      Code
+
+      More Code
+---
+  begin
+      Not code
+      Still not code
+
+
+
+
+---
+
+Fenced code inside list
+---
+1. Item one
+2. Item two with code
+   ```
+   ABC
+
+   DEF
+   ```
+3. Item three
+---
+1. Item one
+2. Item two with code
+
+
+
+
+
+3. Item three
+---
+
+Indented code inside list
+---
+1. Item one
+2. Item two with code
+
+       ABC
+
+       DEF
+3. Item three
+---
+1. Item one
+2. Item two with code
+
+
+
+
+3. Item three
+---
+
+Indented text handling after list item
+---
+1. Item one
+2. Item two
+        Not code
+        Still not code
+
+        Code
+3. Item three
+---
+1. Item one
+2. Item two
+        Not code
+        Still not code
+
+
+3. Item three
+---
+
+Inline code (1)
+begin `ABC DEF` end
+begin           end
+
+Inline code (2)
+begin ``ABC`DEF`` end
+begin             end
+
+Inline code (3)
+begin `ABC\` end
+begin        end
+
+Not inline code
+begin \` end
+begin \` end
+
+Multiline inline code (1)
+---
+begin `ABC
+DEF` end
+---
+begin
+     end
+---
+
+Multiline inline code (2)
+---
+begin ``ABC
+`DEF`
+`` end
+---
+begin
+
+   end
+---
+
+Multiline inline code (3)
+---
+begin `maybe code
+
+not code
+---
+begin
+
+not code
+---
+
+Link url (1)
+[a link](#link)
+[a link](     )
+
+Link url (2)
+begin [a link](#link) end
+begin [a link](     ) end
+
+Not a link url (1)
+[a link\](#link)
+[a link\](#link)
+
+Not a link url (2)
+[a link] (#link)
+[a link] (#link)
+
+Link url with newlines before and after link and label
+---
+begin [a link](
+  #target
+  "label"
+) end
+---
+begin [a link](
+
+  "label"
+) end
+---
+
+Link url with spaces
+[a link](<url with spaces>)
+[a link](                 )
+
+Link url with spaces and label
+[a link](<url with spaces> (the label))
+[a link](                  (the label))
+
+Link url with label using double quotes
+begin [a link](#link "label") end
+begin [a link](      "label") end
+
+Link url with label using single quotes
+begin [a link](#link 'label') end
+begin [a link](      'label') end
+
+Link url with label using paren quotes
+begin [a link](#link (label)) end
+begin [a link](      (label)) end
+
+Link with reference (1)
+[a link][ref]
+[a link][   ]
+
+Link with reference (2)
+begin [a link][ref] end
+begin [a link][   ] end
+
+Link definition
+[ref]: #target
+[   ]:
+
+Link definition with label
+[ref]: #taret "label"
+[   ]:        "label"
+
+Link defination: multiline
+---
+[ref]:
+  #target
+   "label"
+done
+---
+[   ]:
+
+   "label"
+done
+---
+
+
+Not a tag
+a < b
+a   b
+
+Invalid tag (1)
+<a href:wrong>
+ a href:wrong
+
+Invalid tag (2)
+begin <a href:wrong> end
+begin  a href:wrong  end
+
+Valid html (1)
+<a href="link">label</a>
+<a href="link">label</a>
+
+Valid html (2)
+begin <a href="link">label</a> end
+begin <a href="link">label</a> end
+
+Multiline valid html (1)
+---
+<a
+  href="link">label</a>
+---
+<a
+  href="link">label</a>
+---
+
+Multiline valid html (2)
+---
+begin <a
+  href="link">label</a>
+end
+---
+begin <a
+  href="link">label</a>
+end
+---
+
+Multiline valid html (3)
+---
+begin <a
+href="link">label</a> end
+---
+begin <a
+href="link">label</a> end
+---
+
+Multiline invalid
+---
+begin <atag !!!
+>text</atag> end
+---
+begin  atag !!!
+ text</atag> end
+---
+
+
+HTML block case 1
+---
+<script>
+I can be multiline.
+
+<not a tag> `I am NOT code`
+</script>
+And now I am no longer in the block:
+<not a tag> `I am NOT code`
+---
+<script>
+I can be multiline.
+
+<not a tag> `I am NOT code`
+</script>
+And now I am no longer in the block:
+ not a tag
+---
+
+HTML block case 1 uppercase tags
+---
+<SCRIPT>
+I can be multiline.
+
+<not a tag> `I am NOT code`
+</SCRIPT>
+And now I am no longer in the block:
+<not a tag> `I am NOT code`
+---
+<SCRIPT>
+I can be multiline.
+
+<not a tag> `I am NOT code`
+</SCRIPT>
+And now I am no longer in the block:
+ not a tag
+---
+
+HTML comment
+<!-- `I am not code` -->
+<!-- `I am not code` -->
+
+HTML block case 6
+---
+<h1>`NOT code`</h1>
+`still not code`
+
+`code`
+end
+---
+<h1>`NOT code`</h1>
+`still not code`
+
+
+end
+---
+
+HTML block case 6 uppercase tags
+---
+<H1>`NOT code`</H1>
+`still not code`
+
+`code`
+end
+---
+<H1>`NOT code`</H1>
+`still not code`
+
+
+end
+---
+
+HTML block case 6 multiline starting tag
+---
+<h1
+>A Heading `and not code`
+</h1>
+
+`code`
+end
+---
+<h1
+>A Heading `and not code`
+</h1>
+
+
+end
+---
+
+HTML block case 7
+---
+<sometag>
+`not code`
+
+`code`
+
+</sometag>
+---
+<sometag>
+`not code`
+
+
+
+</sometag>
+---
+
+HTML block invalid case 7
+---
+<sometag> `code?`
+
+`code`
+
+</sometag>
+---
+<sometag>
+
+
+
+</sometag>
+---


### PR DESCRIPTION
Todo:
- [x] Document new filter in manual
- [x] Rebase to clean up commits
- [x] Check in test script

Closes #536.

Use `aspell --mode=markdown` to use.

To see what is being ignored use `aspell filter --mode=markdown`.