### PR TITLE
Fix 1 excessive dependency in Makefile.am

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -248,7 +248,7 @@ filter_DATA = $(fltfiles)
 
 # settings.h added as a dependency so it will get recreated if
 #   the COMPILE_IN_FILTERS option changes
-gen/static_filters.src.cpp: ${static_optfiles} gen/mk-static-filter.pl gen/settings.h
+gen/static_filters.src.cpp: ${static_optfiles} gen/mk-static-filter.pl
 	${PERLPROG} ${srcdir}/gen/mk-static-filter.pl $(addprefix ${srcdir}/,${static_optfiles})
 
 ${srcdir}/lib/new_filter.cpp: gen/static_filters.src.cpp

--- a/Makefile.am
+++ b/Makefile.am
@@ -246,8 +246,6 @@ noinst_DATA += $(static_optfiles) gen/filter.pot
 opt_DATA = $(dynamic_optfiles)
 filter_DATA = $(fltfiles)
 
-# settings.h added as a dependency so it will get recreated if
-#   the COMPILE_IN_FILTERS option changes
 gen/static_filters.src.cpp: ${static_optfiles} gen/mk-static-filter.pl
 	${PERLPROG} ${srcdir}/gen/mk-static-filter.pl $(addprefix ${srcdir}/,${static_optfiles})
 


### PR DESCRIPTION
Hi, I've fixed 1 excessive dependency reported.
Those issues can cause unnecessary rebuilds when `aspell` is incrementally built.

Detailed speaking, any changes in `gen/settings.h` will the unnecessary rebuild of `gen/static_filters.src.cpp`, which can slow down the build process of the total project.

I modify the Makefile.am to remove this excessive dependency. I've checked and the new Makefile.am works well.
Looking forward to your confirmation.

Thanks
Vemake