### PR TITLE
Don't allow null-terminated UCS-2/4 strings using the original API. 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,6 +109,8 @@ jobs:
     #
     - run: ./autogen
     - run: make -j2 -C test
+    - run: rm test/build/Makefile
+    - run: make SLOPPY=1 -j2 -C test
 
 workflows:
   version: 2

--- a/auto/MkSrc/Create.pm
+++ b/auto/MkSrc/Create.pm
@@ -77,8 +77,10 @@ sub create_cc_file ( % )  {
   $file .= "#include \"aspell.h\"\n" if $p{type} eq 'cxx';
   $file .= "#include \"settings.h\"\n" if $p{type} eq 'native_impl' && $p{name} eq 'errors';
   $file .= "#include \"gettext.h\"\n" if $p{type} eq 'native_impl' && $p{name} eq 'errors';
+  $file .= cmap {"#include <$_>\n"} sort keys %{$accum{sys_headers}};
   $file .= cmap {"#include \"".to_lower($_).".hpp\"\n"} sort keys %{$accum{headers}};
-  $file .= "#ifdef __cplusplus\nextern \"C\" {\n#endif\n" if $p{header} && !$p{cxx};
+  $file .= "\n#ifdef __cplusplus\nextern \"C\" {\n#endif\n" if $p{header} && !$p{cxx};
+  $file .= join('', grep {defined $_} @{$accum{prefix}});
   $file .= "\nnamespace $p{namespace} {\n\n" if $p{cxx};
   if (defined $info{forward}{proc}{$p{type}}) {
     my @types = sort {$a->{name} cmp $b->{name}} (values %{$accum{types}});
@@ -86,6 +88,7 @@ sub create_cc_file ( % )  {
   }
   $file .= "\n";
   $file .= $body;
+  $file .= join('', grep {defined $_} @{$accum{suffix}});
   $file .= "\n\n}\n\n" if $p{cxx};
   $file .= "#ifdef __cplusplus\n}\n#endif\n" if $p{header} && !$p{cxx};
   $file .= "#endif /* $hm */\n" if $p{header};

--- a/auto/MkSrc/Info.pm
+++ b/auto/MkSrc/Info.pm
@@ -60,6 +60,7 @@ each proc sub should take the following argv
     the object from which it is a member of
   no native: do not attempt to create a native implementation
   treat as object: treat as a object rather than a pointer
+  no conv: do not converted an encoded string
 
 The %info structure is initialized as follows:
 
@@ -104,8 +105,8 @@ The %info structure is initialized as follows:
   errors => {}, # possible errors
   method => {
     # A class method
-    options => ['desc', 'posib err', 'c func', 'const',
-		'c only', 'c impl', 'cxx impl'],
+    options => ['desc', 'posib err', 'c func', 'const', 'no conv', 'on conv error',
+		'c only', 'c impl', 'cxx impl', 'cc extra'],
     groups => undef},
   constructor => {
     # A class constructor

--- a/auto/MkSrc/Read.pm
+++ b/auto/MkSrc/Read.pm
@@ -88,13 +88,13 @@ sub advance ( ) {
     $in_pod = $1 if $line =~ /^\=(\w+)/;
     $line = '' if $in_pod;
     $in_pod = undef if $in_pod && $in_pod eq 'cut';
-    $line =~ s/\#.*$//;
+    $line =~ s/(?<!\\)\#.*$//;
     $line =~ s/^(\t*)//;
     $level = $base_level + length($1);
       $line =~ s/\s*$//;
     ++$base_level if $line =~ s/^\{$//;
     --$base_level if $line =~ s/^\}$//;
-    $line =~ s/\\([{}])/$1/g;
+    $line =~ s/\\([{}#\\])/$1/g;
   } while ($line eq '');
   #print "$level:$line\n";
 }

--- a/auto/mk-src.in
+++ b/auto/mk-src.in
@@ -608,6 +608,7 @@ errors:
 		invalid expression
 			mesg => "%expression" is not a valid regular expression.
 			parms => expression
+
 }
 group: speller
 {
@@ -650,6 +651,7 @@ class: speller
 		posib err
 		desc => Returns 0 if it is not in the dictionary,
 			1 if it is, or -1 on error.
+		on conv error => return 0;
 		/
 		bool
 		encoded string: word
@@ -715,6 +717,8 @@ class: speller
 		desc => Return NULL on error.
 			The word list returned by suggest is only
 			valid until the next call to suggest.
+		on conv error =>
+			word = NULL; word_size = 0;
 		/
 		const word list
 		encoded string: word
@@ -840,7 +844,6 @@ class: document checker
 		void
 
 	method: process
-
 		desc => Process a string.
 			The document is expected to be passed in one or more
 			lines at a time.  Splitting the document on
@@ -852,10 +855,10 @@ class: document checker
 			in the document.  Passing in strings out of
 			order, skipping strings or passing them in
 			more than once may lead to undefined results.
+		no conv
 		/
 		void
-		string: str
-		int: size
+		encoded string: str
 
 	method: next misspelling
 
@@ -863,8 +866,22 @@ class: document checker
 			processed string.  If there are no more
 			misspelled words, then token.word will be
 			NULL and token.size will be 0
+		cc extra =>
+			\#define aspell_document_checker_next_misspelling_w(type, ths) \\
+			    aspell_document_checker_next_misspelling_adj(ths, sizeof(type))
 		/
 		token object
+
+	method: next misspelling adj
+		desc => internal: do not use
+		c impl =>
+			Token res = ths->next_misspelling();
+			res.offset /= type_width;
+			res.len /= type_width;
+			return res;
+		/
+		token object
+		int: type_width
 
 	method: filter
 
@@ -925,9 +942,30 @@ class: string enumeration
 			  ths->from_internal_->append_null(ths->temp_str);
 			  return ths->temp_str.data();
 			\}
+		cc extra =>
+			\#define aspell_string_enumeration_next_w(type, ths) \\
+			    aspell_cast_(const type *, aspell_string_enumeration_next_wide(ths, sizeof(type)))
 		/
 		const string
 
+	method: next wide
+		c impl =>
+			const char * s = ths->next();
+			if (s == 0) {
+			  return s;
+			} else if (ths->from_internal_ == 0) \{
+			  assert(type_width == 1);
+			  return s;
+			\} else \{
+			  assert(type_width == ths->from_internal_->out_type_width());
+			  ths->temp_str.clear();
+			  ths->from_internal_->convert(s,-1,ths->temp_str);
+			  ths->from_internal_->append_null(ths->temp_str);
+			  return ths->temp_str.data();
+			\}
+		/
+		const void pointer
+		int: type_width
 }
 group: info
 {

--- a/common/document_checker.cpp
+++ b/common/document_checker.cpp
@@ -44,7 +44,9 @@ namespace acommon {
   void DocumentChecker::process(const char * str, int size)
   {
     proc_str_.clear();
-    conv_->decode(str, size, proc_str_);
+    PosibErr<int> fixed_size = get_correct_size("aspell_document_checker_process", conv_->in_type_width(), size);
+    if (!fixed_size.has_err())
+      conv_->decode(str, fixed_size, proc_str_);
     proc_str_.append(0);
     FilterChar * begin = proc_str_.pbegin();
     FilterChar * end   = proc_str_.pend() - 1;
@@ -53,6 +55,19 @@ namespace acommon {
     tokenizer_->reset(begin, end);
   }
 
+  void DocumentChecker::process_wide(const void * str, int size, int type_width)
+  {
+    proc_str_.clear();
+    int fixed_size = get_correct_size("aspell_document_checker_process", conv_->in_type_width(), size, type_width);
+    conv_->decode(static_cast<const char *>(str), fixed_size, proc_str_);
+    proc_str_.append(0);
+    FilterChar * begin = proc_str_.pbegin();
+    FilterChar * end   = proc_str_.pend() - 1;
+    if (filter_)
+      filter_->process(begin, end);
+    tokenizer_->reset(begin, end);
+  }
+  
   Token DocumentChecker::next_misspelling()
   {
     bool correct;

--- a/common/document_checker.hpp
+++ b/common/document_checker.hpp
@@ -36,6 +36,7 @@ namespace acommon {
     PosibErr<void> setup(Tokenizer *, Speller *, Filter *);
     void reset();
     void process(const char * str, int size);
+    void process_wide(const void * str, int size, int type_width);
     Token next_misspelling();
     
     Filter * filter() {return filter_;}

--- a/common/version.cpp
+++ b/common/version.cpp
@@ -1,8 +1,17 @@
 #include "settings.h"
 
-extern "C" const char * aspell_version_string() {
 #ifdef NDEBUG
-  return VERSION " NDEBUG";
+#  define NDEBUG_STR " NDEBUG"
+#else
+#  define NDEBUG_STR
 #endif
-  return VERSION;
+
+#ifdef SLOPPY_NULL_TERM_STRINGS
+#  define SLOPPY_STR " SLOPPY"
+#else
+#  define SLOPPY_STR
+#endif
+
+extern "C" const char * aspell_version_string() {
+  return VERSION NDEBUG_STR SLOPPY_STR;
 }

--- a/configure.ac
+++ b/configure.ac
@@ -73,6 +73,9 @@ AC_ARG_ENABLE(filter-version-control,
 AC_ARG_ENABLE(32-bit-hash-fun,
   AS_HELP_STRING([--enable-32-bit-hash-fun],[use 32-bit hash function for compiled dictionaries]))
 
+AC_ARG_ENABLE(sloppy-null-term-strings,
+  AS_HELP_STRING([--enable-sloppy-null-term-strings],[allows allow null terminated UCS-2 and UCS-4 strings]))
+
 AC_ARG_ENABLE(pspell-compatibility,
   AS_HELP_STRING([--disable-pspell-compatibility],[don't install pspell compatibility libraries]))
 
@@ -139,6 +142,11 @@ AM_CONDITIONAL(COMPILE_IN_FILTERS,
 if test "$enable_32_bit_hash_fun" = "yes"
 then
   AC_DEFINE(USE_32_BIT_HASH_FUN, 1, [Defined if 32-bit hash function should be used for compiled dictionaries.])
+fi
+
+if test "$enable_sloppy_null_term_strings" = "yes"
+then
+  AC_DEFINE(SLOPPY_NULL_TERM_STRINGS, 1, [Defined if null-terminated UCS-2 and UCS-4 strings should always be allowed.])
 fi
 
 AM_CONDITIONAL(PSPELL_COMPATIBILITY,  

--- a/manual/aspell.texi
+++ b/manual/aspell.texi
@@ -4356,6 +4356,8 @@ In order to work with the new Markdown filter
 time.  If the document is split on white space characters instead,
 nothing will break, but new filters such as the Markdown filter may
 give incorrect results.
+@item
+Fix various crashes and other problems found by Google's OSS-Fuzz.
 @end itemize
 
 @heading Changes from 0.60.6.1 to 0.60.7 (July 29, 2019)

--- a/manual/aspell.texi
+++ b/manual/aspell.texi
@@ -158,7 +158,8 @@ Installing
 
 * Generic Install Instructions::  
 * HTML Manuals and "make clean"::  
-* Curses Notes::                
+* Curses Notes::
+* Upgrading from Aspell 0.60.7::
 * Loadable Filter Notes::       
 * Upgrading from Aspell 0.50::  
 * Upgrading from Aspell .33/Pspell .12::  
@@ -2272,18 +2273,26 @@ int correct = aspell_speller_check(spell_checker, @var{word}, @var{size});
 @end smallexample
 
 @noindent
-@var{word} is expected to be a @code{const char *} character
-string.  If the encoding is set to be @code{ucs-2} or
-@code{ucs-4} @var{word} is expected to be a cast
-from either @code{const u16int *} or @code{const u32int *}
-respectively.  @code{u16int} and @code{u32int} are generally
-@code{unsigned short} and @code{unsigned int} respectively.
-@var{size} is the length of the string or @code{-1} if the string
-is null terminated.  If the string is a cast from @code{const u16int
-*} or @code{const u32int *} then @code{@i{size}} is the amount of
-space in bytes the string takes up after being cast to @code{const
-char *} and not the true size of the string.  @code{sspell_speller_check}
-will return @code{0} if it is not found and non-zero otherwise.
+@var{word} is expected to be a @code{const char *} character string.
+@var{size} is the length of the string or @code{-1} if the string is
+null terminated.  @code{aspell_speller_check} will return @code{0} if it is not found
+and non-zero otherwise.
+
+If you are using the @code{ucs-2} or @code{ucs-4} encoding then the
+string is expected to be either a 2 or 4 byte wide integer
+(respectively) and the @code{_w} macro vesion should be used:
+
+@smallexample
+int correct = aspell_speller_check_w(spell_checker, @var{word}, @var{size});
+@end smallexample
+
+The macro will cast the string to to the correct type and convert
+@var{size} into bytes for you and then a call the special wide version of the
+function that will make sure the encoding is correct for the type
+passed in.  For compatibility with older versions of Aspell the normal
+non-wide functions can still be used provided that the size of the
+string, in bytes, is also passed in.  Null terminated @code{ucs-2} or
+@code{ucs-4} are no longer supported when using the non-wide functions.
 
 If the word is not correct, then the @code{suggest} method can be used
 to come up with likely replacements.
@@ -2302,7 +2311,28 @@ delete_aspell_string_enumeration(elements);
 
 Notice how @code{elements} is deleted but @code{suggestions} is not.
 The value returned by @code{suggestions} is only valid to the next
-call to @code{suggest}.  Once a replacement is made the
+call to @code{suggest}.
+
+If you are using the @code{ucs-2} or @code{ucs-4} encoding then, in
+addition to using the @code{_w} macro for the @code{suggest} method, you
+should also use the @code{_w} macro with the @code{next} method which
+will cast the string to the correct type for you.  For example, if you
+are using the @code{ucs-2} encoding and the string is a @code{const
+uint16_t *} then you should use:
+
+@smallexample
+AspellWordList * suggestions = aspell_speller_suggest_w(spell_checker,
+                                                        @var{word}, @var{size});
+AspellStringEnumeration * elements = aspell_word_list_elements(suggestions);
+const uint16_t * word;
+while ( (word = aspell_string_enumeration_next_w(uint16_t, aspell_elements)) != NULL )
+@{
+  // add to suggestion list
+@}
+delete_aspell_string_enumeration(elements);
+@end smallexample
+
+Once a replacement is made the
 @code{store_repl} method should be used to communicate the replacement
 pair back to the spell checker (for the reason, @pxref{Notes on
 Storing Replacement Pairs}).  Its usage is as follows:
@@ -4338,14 +4368,21 @@ a C++ program.
 @heading Changes from 0.60.7 to 0.68.8 (???)
 @itemize @bullet
 @item
-When typo analysis is used ensure that possible typos are listed
+Add Markdown filter.
+@item
+When typo analysis is used, ensure that possible typos are listed
 before other suggestions.  Also fix a bug so that suggestions that split
 a word using a space or hyphen are not always first.
 @item
 Change @code{ultra} suggestion mode to only find words that are within
 one-edit distance or have the same soundslike.
 @item
-Add Markdown filter.
+To prevent a potentially unbounded buffer over-read Aspell no longer
+supports null-terminated UCS-2 and UCS-4 encoded strings with the
+original C API. @xref{Upgrading from Aspell 0.60.7}.
+@item
+Fix a bug in @code{AspellDocumentChecker} that prevented it from
+working with UCS-2 and UCS-4 encoded strings.
 @item
 Implement @code{aspell filter} command.
 @item

--- a/manual/readme.texi
+++ b/manual/readme.texi
@@ -15,15 +15,16 @@ The latest version can always be found at GNU Aspell's home page at
 @uref{http://aspell.net}.
 
 @menu
-* Generic Install Instructions::  
-* HTML Manuals and "make clean"::  
-* Curses Notes::                
-* Loadable Filter Notes::       
-* Using 32-Bit Dictionaries on a 64-Bit System::  
-* Upgrading from Aspell 0.50::  
-* Upgrading from Aspell .33/Pspell .12::  
-* Upgrading from a Pre-0.50 snapshot::  
-* WIN32 Notes::                 
+* Generic Install Instructions::
+* HTML Manuals and "make clean"::
+* Curses Notes::
+* Upgrading from Aspell 0.60.7::
+* Loadable Filter Notes::
+* Using 32-Bit Dictionaries on a 64-Bit System::
+* Upgrading from Aspell 0.50::
+* Upgrading from Aspell .33/Pspell .12::
+* Upgrading from a Pre-0.50 snapshot::
+* WIN32 Notes::
 @end menu
 
 @node Generic Install Instructions
@@ -121,17 +122,62 @@ In addition your system must also support the @code{mblen} function.
 Although this function was defined in the ISO C89 standard (ANSI
 X3.159-1989), not all systems have it.
 
+@node Upgrading from Aspell 0.60.7
+@appendixsec Upgrading from Aspell 0.60.7
+
+To prevent a potentially unbounded buffer over-read, Aspell no longer
+supports null-terminated UCS-2 and UCS-4 encoded strings with the
+original C API.  Null-termianted 8-bit or UTF-8 encoded strings are
+still supported, as are UCS-2 and UCS-4 encoded strings when the
+length is passed in.
+
+As of Aspell 0.60.8 a function from the original API that expects an
+encoded string as a parameter will return meaningless results (or an
+error code) if string is null terminated and the encoding is set to
+@code{ucs-2} or @code{ucs-4}.  In addition, a single:
+@example
+ERROR: aspell_speller_check: Null-terminated wide-character strings unsupported when used this way.
+@end example
+will be printed to standard error the first time one of those
+functions is called.
+
+Application that use null-terminated UCS-2/4 strings should either (1)
+use the interface intended for working with wide-characters
+(@xref{Through the C API}); or (2) define
+@code{ASPELL_ENCODE_SETTING_SECURE} before including @code{aspell.h}.
+In the latter case is is important that the application explicitly
+sets the encoding to a known value.  Defining
+@code{ASPELL_ENCODE_SETTING_SECURE} and not setting the encoding
+explicitly or allowing user of the application to set the encoding
+could result in an unbounded buffer over-read.
+
+If it is necessary to preserve binary compatibility with older
+versions of Aspell, the easiest thing would be to determine the length
+of the UCS-2/4 string---in bytes---and pass that in.  Due to an
+implemenation detail, existing API functions can be made to work with
+null-terminated UCS-2/4 strings safely by passing in either @code{-2}
+or @code{-4} (corresponding to the width of the character type) as the
+size.  Doing so, however, will cause a buffer over-read for unpatched
+version of Aspell.  To avoid this it will be necessary to parse the
+version string to determine the correct value to use.  However, no
+official support will be provided for the latter method.
+
+If the application can not be recompiled, then Aspell can be configured
+to preserve the old behavior by passing
+@option{--enable-sloppy-null-term-strings} to @command{configure}.  When Aspell
+is compiled this way the version string will include the string
+@samp{ SLOPPY}.
+
 @node Loadable Filter Notes
 @appendixsec Loadable Filter Notes
-
+             
 Support for being able to load additional filter modules at run-time
 has only been verified to work on Linux platforms.  If you get linker
 errors when trying to use a filter, then it is likely that loadable
 filter support is not working yet on your platform.  Thus, in order to
 get Aspell to work correctly you will need to avoid compiling the
 filters as individual modules by using the
-@option{--enable-compile-in-filters} when configuring Aspell with
-@command{./configure}.
+@option{--enable-compile-in-filters} @command{configure} option.
 
 @node Using 32-Bit Dictionaries on a 64-Bit System
 @appendixsec Using 32-Bit Dictionaries on a 64-Bit System

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,10 +1,11 @@
 CXXFLAGS = -O -g
-CFLAGS   = -O -g
+CFLAGS   = -O -g -Wall
 export ASPELL = ${CURDIR}/inst/bin/aspell
 export PREZIP = ${CURDIR}/inst/bin/prezip-bin
 MAKE := ${MAKE} "CXXFLAGS=${CXXFLAGS}" "CFLAGS=${CFLAGS}"
+EXTRA_CONFIG_FLAGS =
 
-all:: prep sanity filter-test suggest
+all:: prep sanity filter-test suggest wide cxx_warnings
 	cat test-res
 
 prep:: inst/bin/aspell inst/lib/aspell-0.60/en.multi tmp
@@ -35,7 +36,7 @@ inst/lib/aspell-0.60/en.multi: inst/bin/aspell aspell6-en-2018.04.16-0.tar.bz2
 
 build/Makefile:
 	mkdir -p build
-	cd build && ../../configure --enable-maintainer-mode --disable-shared --disable-pspell-compatibility --prefix="${CURDIR}/inst"
+	cd build && ../../configure --enable-maintainer-mode --disable-shared --disable-pspell-compatibility --prefix="${CURDIR}/inst" $(EXTRA_CONFIG_FLAGS)
 
 aspell6-en-2018.04.16-0.tar.bz2:
 	curl -O ftp://ftp.gnu.org/gnu/aspell/dict/en/aspell6-en-2018.04.16-0.tar.bz2
@@ -47,6 +48,33 @@ suggest.mk: suggest/mkmk
 	suggest/mkmk > suggest.mk
 
 include suggest.mk
+
+wide:: wide_test_invalid wide_test_invalid-but_ok wide_test_valid
+
+wide_test_invalid: wide_test_invalid.c prep
+	$(CC) $(CFLAGS) -Iinst/include -c $< -o tmp/$@.o
+	$(CXX) tmp/$@.o inst/lib/libaspell.a -ldl -o $@
+	./$@ 2> tmp/$@.log || true
+	fgrep -q 'Null-terminated wide-character strings unsupported when used this way.' tmp/$@.log
+
+wide_test_valid: wide_test_valid.c prep
+	$(CC) $(CFLAGS) -Iinst/include -c $< -o tmp/$@.o
+	$(CXX) tmp/$@.o inst/lib/libaspell.a -ldl -o $@
+	./$@
+
+wide_test_invalid-but_ok: wide_test_invalid.c prep
+	$(CC) $(CFLAGS) -DASPELL_ENCODE_SETTING_SECURE -Iinst/include -c $< -o tmp/$@.o
+	$(CXX) tmp/$@.o inst/lib/libaspell.a -ldl -o $@
+	./$@
+
+cxx_warnings:  cxx_warnings_test.cpp prep
+	$(CXX) $(CXXFLAGS) -Wall -Wconversion -Werror -Iinst/include -c $<
+
+## this target is only true if configured with --enable-sloppy-null-term-strings
+wide_test_invalid-but_allowed: wide_test_invalid.c prep
+	$(CC) $(CFLAGS) -Iinst/include -c $< inst/lib/libaspell.a -ldl -o tmp/obj.o
+	$(CXX) tmp/obj.o inst/lib/libaspell.a -ldl -o $@
+	./$@
 
 .PHONY: phony
 phony:

--- a/test/Makefile
+++ b/test/Makefile
@@ -4,6 +4,9 @@ export ASPELL = ${CURDIR}/inst/bin/aspell
 export PREZIP = ${CURDIR}/inst/bin/prezip-bin
 MAKE := ${MAKE} "CXXFLAGS=${CXXFLAGS}" "CFLAGS=${CFLAGS}"
 EXTRA_CONFIG_FLAGS =
+ifdef SLOPPY
+  EXTRA_CONFIG_FLAGS += --enable-sloppy-null-term-strings
+endif
 
 all:: prep sanity filter-test suggest wide cxx_warnings
 	cat test-res
@@ -23,7 +26,7 @@ filter-test:: prep
 	echo "all ok (markdown filter-test)" >> test-res
 
 inst/bin/aspell: build/Makefile phony
-	$(MAKE) -C build install
+	$(MAKE) -C build aspell && cmp build/aspell inst/bin/aspell || $(MAKE) -s -C build install
 
 inst/lib/aspell-0.60/en.multi: inst/bin/aspell aspell6-en-2018.04.16-0.tar.bz2
 	tar xf aspell6-en-2018.04.16-0.tar.bz2
@@ -36,7 +39,7 @@ inst/lib/aspell-0.60/en.multi: inst/bin/aspell aspell6-en-2018.04.16-0.tar.bz2
 
 build/Makefile:
 	mkdir -p build
-	cd build && ../../configure --enable-maintainer-mode --disable-shared --disable-pspell-compatibility --prefix="${CURDIR}/inst" $(EXTRA_CONFIG_FLAGS)
+	cd build && ../../configure -q --enable-maintainer-mode --disable-shared --disable-pspell-compatibility --prefix="${CURDIR}/inst" $(EXTRA_CONFIG_FLAGS) 
 
 aspell6-en-2018.04.16-0.tar.bz2:
 	curl -O ftp://ftp.gnu.org/gnu/aspell/dict/en/aspell6-en-2018.04.16-0.tar.bz2
@@ -54,27 +57,30 @@ wide:: wide_test_invalid wide_test_invalid-but_ok wide_test_valid
 wide_test_invalid: wide_test_invalid.c prep
 	$(CC) $(CFLAGS) -Iinst/include -c $< -o tmp/$@.o
 	$(CXX) tmp/$@.o inst/lib/libaspell.a -ldl -o $@
+ifdef SLOPPY
+	./$@
+	echo "ok ($@ SLOPPY)" >> test-res
+else
 	./$@ 2> tmp/$@.log || true
 	fgrep -q 'Null-terminated wide-character strings unsupported when used this way.' tmp/$@.log
+	echo "ok ($@)" >> test-res
+endif
 
 wide_test_valid: wide_test_valid.c prep
 	$(CC) $(CFLAGS) -Iinst/include -c $< -o tmp/$@.o
 	$(CXX) tmp/$@.o inst/lib/libaspell.a -ldl -o $@
 	./$@
+	echo "ok ($@)" >> test-res
 
 wide_test_invalid-but_ok: wide_test_invalid.c prep
 	$(CC) $(CFLAGS) -DASPELL_ENCODE_SETTING_SECURE -Iinst/include -c $< -o tmp/$@.o
 	$(CXX) tmp/$@.o inst/lib/libaspell.a -ldl -o $@
 	./$@
+	echo "ok ($@)" >> test-res
 
 cxx_warnings:  cxx_warnings_test.cpp prep
 	$(CXX) $(CXXFLAGS) -Wall -Wconversion -Werror -Iinst/include -c $<
-
-## this target is only true if configured with --enable-sloppy-null-term-strings
-wide_test_invalid-but_allowed: wide_test_invalid.c prep
-	$(CC) $(CFLAGS) -Iinst/include -c $< inst/lib/libaspell.a -ldl -o tmp/obj.o
-	$(CXX) tmp/obj.o inst/lib/libaspell.a -ldl -o $@
-	./$@
+	echo "ok ($@)" >> test-res
 
 .PHONY: phony
 phony:

--- a/test/cxx_warnings_test.cpp
+++ b/test/cxx_warnings_test.cpp
@@ -1,0 +1,84 @@
+ #include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <aspell.h>
+
+const uint16_t test_word[] = {'c','a','f', 0x00E9, 0};
+const uint16_t test_incorrect[] = {'c','a','f', 'e', 0};
+const uint16_t test_doc[] = {'T', 'h', 'e', ' ', 'c','a','f', 0x00E9, '.', 0};
+
+int fail = 0;
+
+void f1() {
+  AspellConfig * spell_config = new_aspell_config();
+  aspell_config_replace(spell_config, "master", "en_US-w_accents");
+  aspell_config_replace(spell_config, "encoding", "ucs-2");
+  AspellCanHaveError * possible_err = new_aspell_speller(spell_config);
+  AspellSpeller * spell_checker = 0;
+  if (aspell_error_number(possible_err) != 0) {
+    fprintf(stderr, "%s", aspell_error_message(possible_err));
+    exit(0);
+  } else {
+    spell_checker = to_aspell_speller(possible_err);
+  }
+  int correct = aspell_speller_check_w(spell_checker, test_word, -1);
+  if (!correct) {
+    fprintf(stderr, "%s", "fail: expected word to be correct\n");
+    fail = 1;
+  }
+  correct = aspell_speller_check_w(spell_checker, test_incorrect, -1);
+  if (correct) {
+    fprintf(stderr, "%s", "fail: expected word to be incorrect\n");
+    fail = 1;
+  }
+  const AspellWordList * suggestions = aspell_speller_suggest_w(spell_checker, test_incorrect, -1);
+  AspellStringEnumeration * elements = aspell_word_list_elements(suggestions);
+  const uint16_t * word = aspell_string_enumeration_next_w(uint16_t, elements);
+  if (memcmp(word, test_word, sizeof(test_incorrect)) != 0) {
+    fprintf(stderr, "%s", "fail: first suggesion is not what is expected\n");
+    fail = 1;
+  delete_aspell_string_enumeration(elements);
+  }
+  if (fail)
+    printf("not ok\n");
+  else
+    printf("ok\n");
+}
+
+void f2() {
+  AspellConfig * spell_config = new_aspell_config();
+  aspell_config_replace(spell_config, "master", "en_US-w_accents");
+  aspell_config_replace(spell_config, "encoding", "ucs-2");
+  AspellCanHaveError * possible_err = new_aspell_speller(spell_config);
+  AspellSpeller * spell_checker = 0;
+  if (aspell_error_number(possible_err) != 0) {
+    fprintf(stderr, "%s", aspell_error_message(possible_err));
+    exit(0);
+  } else {
+    spell_checker = to_aspell_speller(possible_err);
+  }
+  int correct = aspell_speller_check_w(spell_checker, test_word, -1);
+  if (!correct) {
+    fprintf(stderr, "%s", "fail: expected word to be correct\n");
+    fail = 1;
+  }
+  correct = aspell_speller_check_w(spell_checker, test_incorrect, -1);
+  if (correct) {
+    fprintf(stderr, "%s", "fail: expected word to be incorrect\n");
+    fail = 1;
+  }
+  const AspellWordList * suggestions = aspell_speller_suggest_w(spell_checker, test_incorrect, -1);
+  AspellStringEnumeration * elements = aspell_word_list_elements(suggestions);
+  const uint16_t * word = aspell_string_enumeration_next_w(uint16_t, elements);
+  if (memcmp(word, test_word, sizeof(test_incorrect)) != 0) {
+    fprintf(stderr, "%s", "fail: first suggesion is not what is expected\n");
+    fail = 1;
+  delete_aspell_string_enumeration(elements);
+  }
+  if (fail)
+    printf("not ok\n");
+  else
+    printf("ok\n");
+}

--- a/test/wide_test_invalid.c
+++ b/test/wide_test_invalid.c
@@ -1,0 +1,69 @@
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <aspell.h>
+
+const uint16_t test_word[] = {'c','a','f', 0x00E9, 0};
+const uint16_t test_incorrect[] = {'c','a','f', 'e', 0};
+const uint16_t test_doc[] = {'T', 'h', 'e', ' ', 'c','a','f', 'e', '.', 0};
+
+int fail = 0;
+
+int main() {
+  AspellConfig * spell_config = new_aspell_config();
+  aspell_config_replace(spell_config, "master", "en_US-w_accents");
+  aspell_config_replace(spell_config, "encoding", "ucs-2");
+  AspellCanHaveError * possible_err = new_aspell_speller(spell_config);
+  AspellSpeller * spell_checker = 0;
+  if (aspell_error_number(possible_err) != 0) {
+    fprintf(stderr, "%s", aspell_error_message(possible_err));
+    return 2;
+  } else {
+    spell_checker = to_aspell_speller(possible_err);
+  }
+  int correct = aspell_speller_check(spell_checker, (const char *)test_word, -1);
+  if (!correct) {
+    fprintf(stderr, "%s", "fail: expected word to be correct\n");
+    fail = 1;
+  }
+  correct = aspell_speller_check(spell_checker, (const char *)test_incorrect, -1);
+  if (correct) {
+    fprintf(stderr, "%s", "fail: expected word to be incorrect\n");
+    fail = 1;
+  }
+  const AspellWordList * suggestions = aspell_speller_suggest(spell_checker, (const char *)test_incorrect, -1);
+  AspellStringEnumeration * elements = aspell_word_list_elements(suggestions);
+  const char * word = aspell_string_enumeration_next(elements);
+  if (memcmp(word, test_word, sizeof(test_incorrect)) != 0) {
+    fprintf(stderr, "%s", "fail: first suggesion is not what is expected\n");
+    fail = 1;
+  }
+  delete_aspell_string_enumeration(elements);
+
+  possible_err = new_aspell_document_checker(spell_checker);
+  if (aspell_error(possible_err) != 0) {
+    fprintf(stderr, "Error: %s\n",aspell_error_message(possible_err));
+    return 2;
+  }
+  AspellDocumentChecker * checker = to_aspell_document_checker(possible_err);
+  aspell_document_checker_process(checker, (const char *)test_doc, -1);
+
+  AspellToken token = aspell_document_checker_next_misspelling(checker);
+  if (sizeof(test_incorrect) - sizeof(uint16_t) != token.len) {
+    fprintf(stderr, "fail: size of first misspelling (%d) is not what is expected (%lu)\n",
+            token.len, sizeof(test_incorrect) - sizeof(uint16_t));
+    fail = 1;
+  } else if (memcmp(test_incorrect, (const char *)test_doc + token.offset, token.len) != 0) {
+    fprintf(stderr, "%s", "fail: first misspelling is not what is expected\n");
+    fail = 1;
+  }
+  if (fail) {
+    printf("not ok\n");
+    return 1;
+  } else {
+    printf("ok\n");
+    return 0;
+  }
+}

--- a/test/wide_test_valid.c
+++ b/test/wide_test_valid.c
@@ -1,0 +1,69 @@
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <aspell.h>
+
+const uint16_t test_word[] = {'c','a','f', 0x00E9, 0};
+const uint16_t test_incorrect[] = {'c','a','f', 'e', 0};
+const uint16_t test_doc[] = {'T', 'h', 'e', ' ', 'c','a','f', 'e', '.', 0};
+
+int fail = 0;
+
+int main() {
+  AspellConfig * spell_config = new_aspell_config();
+  aspell_config_replace(spell_config, "master", "en_US-w_accents");
+  aspell_config_replace(spell_config, "encoding", "ucs-2");
+  AspellCanHaveError * possible_err = new_aspell_speller(spell_config);
+  AspellSpeller * spell_checker = 0;
+  if (aspell_error_number(possible_err) != 0) {
+    fprintf(stderr, "%s", aspell_error_message(possible_err));
+    return 2;
+  } else {
+    spell_checker = to_aspell_speller(possible_err);
+  }
+  int correct = aspell_speller_check_w(spell_checker, test_word, -1);
+  if (!correct) {
+    fprintf(stderr, "%s", "fail: expected word to be correct\n");
+    fail = 1;
+  }
+  correct = aspell_speller_check_w(spell_checker, test_incorrect, -1);
+  if (correct) {
+    fprintf(stderr, "%s", "fail: expected word to be incorrect\n");
+    fail = 1;
+  }
+  const AspellWordList * suggestions = aspell_speller_suggest_w(spell_checker, test_incorrect, -1);
+  AspellStringEnumeration * elements = aspell_word_list_elements(suggestions);
+  const uint16_t * word = aspell_string_enumeration_next_w(uint16_t, elements);
+  if (memcmp(word, test_word, sizeof(test_incorrect)) != 0) {
+    fprintf(stderr, "%s", "fail: first suggesion is not what is expected\n");
+    fail = 1;
+  }
+  delete_aspell_string_enumeration(elements);
+  
+  possible_err = new_aspell_document_checker(spell_checker);
+  if (aspell_error(possible_err) != 0) {
+    fprintf(stderr, "Error: %s\n",aspell_error_message(possible_err));
+    return 2;
+  }
+  AspellDocumentChecker * checker = to_aspell_document_checker(possible_err);
+  aspell_document_checker_process_w(checker, test_doc, -1);
+
+  AspellToken token = aspell_document_checker_next_misspelling_w(uint16_t, checker);
+  if (4 != token.len) {
+    fprintf(stderr, "fail: size of first misspelling (%d) is not what is expected (%d)\n",
+            token.len, 4);
+    fail = 1;
+  } else if (memcmp(test_incorrect, test_doc + token.offset, token.len) != 0) {
+    fprintf(stderr, "%s", "fail: first misspelling is not what is expected\n");
+    fail = 1;
+  }
+  if (fail) {
+    printf("not ok\n");
+    return 1;
+  } else {
+    printf("ok\n");
+    return 0;
+  }
+}


### PR DESCRIPTION
Detect if the encoding is UCS-2/4 and the length is -1 in affected API functions and refuse to convert the string.  If the string ends up being converted somehow, abort with an error message in DecodeDirect and ConvDirect.  To convert a null terminated string in Decode/ConvDirect, a negative number corresponding to the width of the underlying character type for the encoding is expected; for example, if the encoding is "ucs-2" then a the size is expected to be -2.

Also fix a 1-3 byte over-read in DecodeDirect when reading UCS-2/4 strings when a size is provided (found by OSS-Fuzz).

Also fix a bug in DecodeDirect that caused DocumentChecker to return the wrong offsets when working with UCS-2/4 strings.