### PR TITLE
Support for data() method call for C++11 and after

### DIFF
--- a/common/vector.hpp
+++ b/common/vector.hpp
@@ -43,48 +43,13 @@ namespace acommon
     
     T * data(int pos) {return data() + pos;}
 
-    T * data_end()
-    {
-      #if __cplusplus < 201103L
-        return &*this->begin() + this->size();
-      #else
-        return this->data() + this->size();
-      #endif
-    }
+    T * data_end() {return this->data() + this->size();}
 
-    T * pbegin()
-    {
-      #if __cplusplus < 201103L
-        return &*this->begin();
-      #else
-        return this->data();
-      #endif
-    }
-    T * pend()
-    {
-      #if __cplusplus < 201103L
-        return &*this->begin() + this->size();
-      #else
-        return this->data() + this->size();
-      #endif
-    }
+    T * pbegin() {return this->data();}
+    T * pend()   {return this->data() + this->size();}
 
-    const T * pbegin() const
-    {
-      #if __cplusplus < 201103L
-        return &*this->begin();
-      #else
-        return this->data();
-      #endif
-    }
-    const T * pend()   const
-    {
-      #if __cplusplus < 201103L
-        return &*this->begin() + this->size();
-      #else
-        return this->data() + this->size();
-      #endif
-    }
+    const T * pbegin() const {return this->data();}
+    const T * pend()   const {return this->data() + this->size();}
 
     template <typename U>
     U * datap() { 

--- a/common/vector.hpp
+++ b/common/vector.hpp
@@ -34,15 +34,57 @@ namespace acommon
       this->resize(pos + s);
       return pos;
     }
-    T * data() {return &*this->begin();}
-    T * data(int pos) {return &*this->begin() + pos;}
-    T * data_end() {return &*this->begin() + this->size();}
 
-    T * pbegin() {return &*this->begin();}
-    T * pend()   {return &*this->begin() + this->size();}
+    #if __cplusplus < 201103L
+      T * data() {return &*this->begin();}
+    #else
+      using std::vector<T>::data;
+    #endif
+    
+    T * data(int pos) {return data() + pos;}
 
-    const T * pbegin() const {return &*this->begin();}
-    const T * pend()   const {return &*this->begin() + this->size();}
+    T * data_end()
+    {
+      #if __cplusplus < 201103L
+        return &*this->begin() + this->size();
+      #else
+        return this->data() + this->size();
+      #endif
+    }
+
+    T * pbegin()
+    {
+      #if __cplusplus < 201103L
+        return &*this->begin();
+      #else
+        return this->data();
+      #endif
+    }
+    T * pend()
+    {
+      #if __cplusplus < 201103L
+        return &*this->begin() + this->size();
+      #else
+        return this->data() + this->size();
+      #endif
+    }
+
+    const T * pbegin() const
+    {
+      #if __cplusplus < 201103L
+        return &*this->begin();
+      #else
+        return this->data();
+      #endif
+    }
+    const T * pend()   const
+    {
+      #if __cplusplus < 201103L
+        return &*this->begin() + this->size();
+      #else
+        return this->data() + this->size();
+      #endif
+    }
 
     template <typename U>
     U * datap() { 


### PR DESCRIPTION
To get a pointer to the first element of the underlying array used by the _vector_, C++11 and beyond, provides the ```data()``` method. 
Support for this call has been added with suitable preprocessor checks for the C++ standard used during compilation.