### PR TITLE
new TeX mode: support for `\(` and `\)` inline math

### DIFF
--- a/modules/filter/tex.cpp
+++ b/modules/filter/tex.cpp
@@ -161,6 +161,12 @@ namespace {
 	} else if (name == "]") {
 	  // \]
 	  pop_command();  // pop DisplayMath
+	} else if (name == "(") {
+	  // \(
+	  push_command(InlineMath, true);
+	} else if (name == ")") {
+	  // \)
+	  pop_command();  // pop InlineMath
 	} else if (args && *args) {
 	  push_command(top.in_what, top.skip, args);
 	}


### PR DESCRIPTION
`\(...\)` is the LaTeX version of `$...$`

These few lines of code are copied from my changes to the pre-git version of aspell. Unfortunately, I have not been able to compile the aspell/new-text-mode branch (with or without this new change). I get errors in files that are totally unrelated to the new TeX mode. Compiling master works.