### PR TITLE
new TeX mode (again)

### DIFF
--- a/manual/aspell.1
+++ b/manual/aspell.1
@@ -210,6 +210,9 @@ Check TeX comments.
 \fB\-\-add\-tex\-command=\fR\fI<list>\fR, \fB\-\-rem\-tex\-command=\fR\fI<list>\fR
 Add or remove a list of TeX commands.
 .TP
+\fB\-\-add\-tex\-ignore\-env=\fR\fI<list>\fR, \fB\-\-rem\-tex\-ignore\-env=\fR\fI<list>\fR
+Add or remove a list of LaTeX environments to skip while spell checking.
+.TP
 \fB\-\-add\-texinfo\-ignore=\fR\fI<list>\fR, \fB\-\-rem\-texinfo\-ignore=\fR\fI<list>\fR
 Add or remove a list of Texinfo commands.
 .TP

--- a/manual/aspell.texi
+++ b/manual/aspell.texi
@@ -1220,10 +1220,18 @@ The @option{tex} (all lowercase) filter hides @TeX{}/LaTeX commands and
 corresponding parameters that are not readable text in the output from
 Aspell.   It also skips over @TeX{} comments by default.
 
+Discretionary hyphens and italic corrections are ignored.  For example,
+@samp{hy\-phen} and @samp{shelf\/ful} are recognized as single words.
+
 @c This filter mode is also available via the
 @c @option{latex} alias name.
 
 @table @b
+
+@item tex-check-comments
+@i{(boolean)}
+Check @TeX{} comments.  Defaults to false.
+
 @item tex-command
 @i{(list)}
 Controls which @TeX{} commands should have certain parameters and/or
@@ -1232,13 +1240,15 @@ all their parameters and/or options checked.  The format for each item
 is
 
 @example
-<command> <a list of p,P,o and Os>
+<command> <a list of 'p', 'P', 'o', 'O' and 'T's>
 @end example
 
 The first item is simply the command name.  The second item controls
 which parameters to skip over.  A 'p' skips over a parameter while a
 'P' doesn't.  Similarly an 'o' will skip over an optional parameter
-while an 'O' doesn't.  The first letter on the list will apply to the
+while an 'O' doesn't.  A 'T' will force spell-checking of a parameter
+even if the command occurs within a parameter or an environment Aspell
+is told to skipped over. The first letter on the list will apply to the
 first parameter, the second letter will apply to the second parameter
 etc.  If there are more parameters than letters Aspell will simply
 check them as normal.  For example the option
@@ -1260,6 +1270,25 @@ will @emph{check} the first parameter of the @code{foo} command, skip
 over the next optional parameter, if it is present, and will skip over
 the second parameter --- even if the optional parameter is not present
 --- and will check any additional parameters.
+
+@example
+add-tex-command foo T
+@end example
+
+@noindent
+will @emph{check} the first parameter of the @code{foo} command even
+if Aspell is currently skipping over an argument or environment.  For
+example, if Aspell has been told to skip over the @code{bar}
+environment (@pxref{Ignoring LaTeX Environments}), then in the text
+
+@example
+\begin@{bar@} don't check \foo@{check@} don't check \end@{bar@}
+@end example
+
+@noindent
+it will nevertheless @emph{check} the argument to @code{foo}.  This is
+useful to force checking of arguments to text-related commands like
+@code{hbox}, @code{text} or @code{intertext} inside math environments.
 
 A @samp{*} at the end of the command is simply ignored.  For example
 the option
@@ -1287,14 +1316,55 @@ current defaults.
 @c will remove the command foo, if present, from the list of @TeX{}
 @c commands.
 
-@item tex-check-comments
-@i{(boolean)}
-Check @TeX{} comments.  Defaults to false.
+@anchor{Ignoring LaTeX Environments}
+@item tex-ignore-env
+@i{(list)}
+This controls which @TeX{} environments are skipped over.  By default,
+Aspell will skip over math formulas inside @code{$...$}, @code{$$...$$},
+@code{\(...\)} and @code{\[...\]} and over several common LaTeX and
+AMS-LaTeX math environments like @code{equation} and @code{gather}.
+For example,
+
+@example
+add-tex-ignore-env thebibliography
+@end example
+
+@noindent
+will tell Aspell to skip over the bibliography as well (which may or
+may not be a good idea).  As with commands, skipping applies to the
+starred form of the environment as well.
+
+@example
+rem-tex-ignore-env equation
+@end example
+
+@noindent
+will make Aspell spell-check the contents of @code{equation} and
+@code{equation*} environments.  Skipping the contents of @code{$...$},
+@code{$$...$$}, @code{\(...\)} and @code{\[...\]} cannot be turned off.
+
+Note that one can force spell-checking of arguments to TeX commands
+inside ignored environments with the 'T' parameter to the
+@option{add-tex-command} option.
 
 @c @item tex-multi-byte
 @c (@i{list}) TeX multi byte letter en|decoding
 
 @end table
+
+As a last resort, spell checking can be switched off by putting the
+text @code{aspell:off} into the file. Similarly, with @code{aspell:on}
+one can turn it on again. This can be useful for macro definitions,
+for example
+
+@example
+% aspell:off
+\def\doi#1@{\href@{http://doi.org/#1@}@{doi:#1@}@}
+% aspell:on
+@end example
+
+@noindent
+This feature is implemented via the @ref{Context Filter}.
 
 @c The TeXfilter mode also contains a decoding and an encoding filter for
 @c @emph{babel} character codes like the German Umlauts:
@@ -1404,6 +1474,7 @@ escapes
 (@code{\(}) and extended (@code{\[comp1 comp2 @dots{}]}) form.
 @end itemize
 
+@anchor{Context Filter}
 @subsubsection Context Filter
 
 The @option{context} filter can be used to spell check source codes,

--- a/modules/filter/context.cpp
+++ b/modules/filter/context.cpp
@@ -63,6 +63,7 @@ namespace {
     
   PosibErr<bool> ContextFilter::setup(Config * config){
     name_ = "context-filter";
+    order_num_ = 0.15;
     StringList delimiters;
     StackPtr<StringEnumeration> delimiterpairs;
     const char * delimiterpair=NULL;

--- a/modules/filter/modes/tex.amf
+++ b/modules/filter/modes/tex.amf
@@ -6,5 +6,8 @@ MAGIC /0:256:^[ \t]*\\documentclass\[[^\[\]]*\]\{[^\{\}]*\}/tex
 
 DESCRIPTION mode for checking TeX/LaTeX documents
 
-FILTER url
+FILTER context
+OPTION clear-context-delimiters
+OPTION add-context-delimiters aspell:off aspell:on
+OPTION enable-context-visible-first
 FILTER tex

--- a/modules/filter/tex-filter.info
+++ b/modules/filter/tex-filter.info
@@ -16,15 +16,35 @@ DESCRIPTION check TeX comments
 DEFAULT false
 ENDOPTION
 
+OPTION ignore-env
+TYPE list
+DESCRIPTION LaTeX environments to be ignored
+# LaTeX
+#DEFAULT thebibliography
+DEFAULT equation
+DEFAULT eqnarray
+# AMS-LaTeX
+DEFAULT gather
+DEFAULT multline
+DEFAULT align
+DEFAULT flalign
+DEFAULT alignat
+# Babel
+DEFAULT otherlanguage
+ENDOPTION
+
 OPTION command
 TYPE list
 DESCRIPTION TeX commands
+# plain TeX / LaTeX
 DEFAULT addtocounter pp
 DEFAULT addtolength pp
-DEFAULT alpha p
+DEFAULT alph p
+DEFAULT Alph p
 DEFAULT arabic p
 DEFAULT fnsymbol p
 DEFAULT roman p
+DEFAULT Roman p
 DEFAULT stepcounter p
 DEFAULT setcounter pp
 DEFAULT usecounter p
@@ -42,7 +62,8 @@ DEFAULT newtheorem poPo
 DEFAULT newfont pp
 DEFAULT documentclass op
 DEFAULT usepackage op
-DEFAULT begin po
+# DO NOT change the next line!
+DEFAULT begin so
 DEFAULT end p
 DEFAULT setlength pp
 DEFAULT addtolength pp
@@ -54,15 +75,17 @@ DEFAULT hyphenation p
 DEFAULT pagenumbering p
 DEFAULT pagestyle p
 DEFAULT addvspace p
-DEFAULT framebox ooP
+DEFAULT framebox ooT
 DEFAULT hspace p
 DEFAULT vspace p
-DEFAULT makebox ooP
-DEFAULT parbox ooopP
-DEFAULT raisebox pooP
+DEFAULT hbox T
+DEFAULT vbox T
+DEFAULT makebox ooT
+DEFAULT parbox ooopT
+DEFAULT raisebox pooT
 DEFAULT rule opp
 DEFAULT sbox pO
-DEFAULT savebox pooP
+DEFAULT savebox pooT
 DEFAULT usebox p
 DEFAULT include p
 DEFAULT includeonly p
@@ -76,13 +99,30 @@ DEFAULT fontshape p
 DEFAULT fontsize pp
 DEFAULT usefont pppp
 DEFAULT documentstyle op
-DEFAULT cite p
+DEFAULT cite Op
 DEFAULT nocite p
 DEFAULT psfig p
 DEFAULT selectlanguage p
 DEFAULT includegraphics op
 DEFAULT bibitem op
+DEFAULT bibliography p
+DEFAULT bibliographystyle p
 DEFAULT geometry p
+# AMS-LaTeX
+DEFAULT address p
+DEFAULT email p
+DEFAULT mathbb p
+DEFAULT mathfrak p
+DEFAULT eqref p
+DEFAULT text T
+DEFAULT intertext T
+DEFAULT DeclareMathOperator pp
+DEFAULT DeclareMathAlphabet ppppp
+# hyperref
+DEFAULT href pP
+DEFAULT autoref p
+DEFAULT url p
+DEFAULT texorpdfstring Pp
 ENDOPTION
 
 #OPTION multi-byte


### PR DESCRIPTION
This patch (hopefully) improves Aspell's TeX mode. It is practically identical to the one posted to the Aspell mailing list [in 2011](https://lists.gnu.org/archive/html/aspell-devel/2011-02/msg00000.html).

**New features implemented by this patch**

- Aspell skips over math content inside `$...$`, `$$..$$`, `\(...\)`, `\[...\]` and common LaTeX and AMS-LaTeX environments like `equation` and `gather`. Additional environments to be skipped over can be defined via the new `tex-ignore-env` list. Otherwise math formulas trigger a huge number of false alarms.

- Forced spell-checking of macro arguments while skipping over arguments or environments. This is achieved with the new `T` option to `add-tex-command`. **Remarks added in 2022 about the `T` option:**
  - I guess the `T` was supposed to mean "toggle". Maybe `F` for "force" would be a better choice.
  - Would it be better to make this the standard behaviour of the `P` option? Asked differently: What LaTeX macros are there using `P` where we don’t want the corresponding argument to be spell checked in math mode? Such a macro should also have arguments without spell checking because otherwise there is no need to define it in Aspell. I can only think of `\textcolor{color}{text}` from `color.sty` (where `text` can also be in math mode!).

- Discretionary hyphens and italic corrections are ignored. For example, `hy\-phen` and `shelf\/ful` are recognized as single words.

- Spell-checking can be manually switched on and off by putting the text `aspell:on` and `aspell:off` into the file. This allows to skip over macro definitions and other parts of text that confuse Aspell.

See the Info file for more details.

**Comments about the changes**

./modules/filter/context.cpp
It seems that the order of the context filter was undefined. Whether one wants to have this filter before or after other filters depends on the application in mind. I need it before the tex filter so that one can place the `aspell:off` and `aspell:on` flags inside TeX comments.

./modules/filter/tex.cpp
The new code for the tex filter.

./modules/filter/tex-filter.info
The new default settings for the filter variables. `tex-ignore-env` is new. Most changes to `tex-command` are related to the new `T` option. The new `begin` line is used internally. The rest are additions and corrections to existing definitions.

./modules/filter/modes/tex.amf
Note that we enable the context filter by default.

./manual/aspell.1
./manual/aspell.texi
Updated documentation.
