### PR TITLE
interface: fix clang `-Wstrict-prototypes` warnings for C interface

### DIFF
--- a/auto/mk-src.in
+++ b/auto/mk-src.in
@@ -224,7 +224,9 @@ class: key info enumeration
 class: config
 	c impl headers => error
 	/
-	constructor
+	constructor: new aspell config
+		/
+		void
 
 	copyable methods
 
@@ -366,6 +368,7 @@ func: version string
 		information on how Aspell was compiled.
 	/
 	string
+	void
 }
 group: error
 {
@@ -1064,7 +1067,9 @@ group: string list
 /
 class: string list
 	/
-	constructor
+	constructor: new aspell string list
+		/
+		void
 
 	list methods
 
@@ -1078,7 +1083,9 @@ group: string map
 /
 class: string map
 	/
-	constructor
+	constructor: new aspell string map
+		/
+		void
 
 	mutable container methods
 


### PR DESCRIPTION
I'm getting the following warnings on macOS: 

```
zaytsev@Yurys-MBP aspell % clang -v
Apple clang version 15.0.0 (clang-1500.3.9.4)
Target: arm64-apple-darwin23.5.0
```

```
/opt/homebrew/include/aspell.h:102:40: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
struct AspellConfig * new_aspell_config();
                                       ^
                                        void
/opt/homebrew/include/aspell.h:195:35: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
const char * aspell_version_string();
                                  ^
                                   void
/opt/homebrew/include/aspell.h:673:49: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
struct AspellStringList * new_aspell_string_list();
                                                ^
                                                 void
/opt/homebrew/include/aspell.h:703:47: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
struct AspellStringMap * new_aspell_string_map();
                                              ^
                                               void
```

I've only got a very superficial understanding of the interface generator, and with my changes, the C interface file now comes out clean. I didn't check any other languages. Appreciate your guidance if I did anything wrong.