### PR TITLE
Remove camel case limit

### DIFF
--- a/config-debug
+++ b/config-debug
@@ -4,5 +4,5 @@ mkdir -p build
 cd build
 ../configure --enable-maintainer-mode \
   --disable-shared --disable-pspell-compatibility\
-  --enable-w-all-error
+  --enable-w-all-error \
   --prefix="`pwd`/../inst" CFLAGS='-g' CXXFLAGS='-g' "$@"

--- a/modules/speller/default/speller_impl.cpp
+++ b/modules/speller/default/speller_impl.cpp
@@ -214,15 +214,6 @@ namespace aspeller {
     return NULL;
   }
 
-  CheckInfo * SpellerImpl::check_camelcase(char * word, char * word_end,
-					   bool try_uppercase, // @kris uppercase as runtogether?
-					   unsigned camel_case_limit,
-					   CheckInfo * ci, CheckInfo * ci_end,
-					   GuessInfo * gi)
-  {
-    return NULL;
-  }
-
   PosibErr<bool> SpellerImpl::check(char * word, char * word_end, 
                                     /* it WILL modify word */
                                     bool try_uppercase,
@@ -234,11 +225,13 @@ namespace aspeller {
     bool res = check_runtogether(word, word_end, try_uppercase, run_together_limit, ci, ci_end, gi);
     if (res) return true;
     
-    CompoundWord cw = lang_->split_word(word, word_end - word, camel_case_); // @kris allcaps words?
+    CompoundWord cw = lang_->split_word(word, word_end - word, camel_case_);
     if (cw.single()) return false;
     bool ok = true;
     CheckInfo * ci_prev = NULL;
+    CheckInfo * ci_overflow = NULL;
     do {
+      if (ci_overflow) ci = ci_overflow;
       unsigned len = cw.word_len();
       
       char save = word[len];
@@ -272,9 +265,10 @@ namespace aspeller {
 
       ci_prev = ci_last;
       ci = ci_last + 1;
-      if (ci >= ci_end) {
-        if (cpi) cpi->count = 0;
-        return false;
+      if (!ci_overflow && ci >= ci_end) {
+        // if (cpi) cpi->count = 0;
+        // return false;
+	ci_overflow = ci_last;
       }
       
       word = word + cw.rest_offset();

--- a/modules/speller/default/speller_impl.cpp
+++ b/modules/speller/default/speller_impl.cpp
@@ -214,6 +214,15 @@ namespace aspeller {
     return NULL;
   }
 
+  CheckInfo * SpellerImpl::check_camelcase(char * word, char * word_end,
+					   bool try_uppercase, // @kris uppercase as runtogether?
+					   unsigned camel_case_limit,
+					   CheckInfo * ci, CheckInfo * ci_end,
+					   GuessInfo * gi)
+  {
+    return NULL;
+  }
+
   PosibErr<bool> SpellerImpl::check(char * word, char * word_end, 
                                     /* it WILL modify word */
                                     bool try_uppercase,
@@ -225,7 +234,7 @@ namespace aspeller {
     bool res = check_runtogether(word, word_end, try_uppercase, run_together_limit, ci, ci_end, gi);
     if (res) return true;
     
-    CompoundWord cw = lang_->split_word(word, word_end - word, camel_case_);
+    CompoundWord cw = lang_->split_word(word, word_end - word, camel_case_); // @kris allcaps words?
     if (cw.single()) return false;
     bool ok = true;
     CheckInfo * ci_prev = NULL;

--- a/modules/speller/default/speller_impl.cpp
+++ b/modules/speller/default/speller_impl.cpp
@@ -266,8 +266,6 @@ namespace aspeller {
       ci_prev = ci_last;
       ci = ci_last + 1;
       if (!ci_overflow && ci >= ci_end) {
-        // if (cpi) cpi->count = 0;
-        // return false;
 	ci_overflow = ci_last;
       }
       

--- a/modules/speller/default/speller_impl.cpp
+++ b/modules/speller/default/speller_impl.cpp
@@ -266,6 +266,8 @@ namespace aspeller {
       ci_prev = ci_last;
       ci = ci_last + 1;
       if (!ci_overflow && ci >= ci_end) {
+        // if (cpi) cpi->count = 0;
+        // return false;
 	ci_overflow = ci_last;
       }
       

--- a/modules/speller/default/speller_impl.cpp
+++ b/modules/speller/default/speller_impl.cpp
@@ -242,6 +242,10 @@ namespace aspeller {
 
       if (!found) {
         if (cpi) {
+	  if (ci_overflow) {
+	    cpi->count = 0;
+	    return false;
+	  }
           ci_last = ci;
           ok = false;
           ci->word.str = word;
@@ -266,8 +270,6 @@ namespace aspeller {
       ci_prev = ci_last;
       ci = ci_last + 1;
       if (!ci_overflow && ci >= ci_end) {
-        // if (cpi) cpi->count = 0;
-        // return false;
 	ci_overflow = ci_last;
       }
       

--- a/modules/speller/default/speller_impl.hpp
+++ b/modules/speller/default/speller_impl.hpp
@@ -132,12 +132,6 @@ namespace aspeller {
                                   CheckInfo *, CheckInfo *,
                                   GuessInfo *);
 
-    CheckInfo * check_camelcase(char * word, char * word_end, /* @kris? it WILL modify word */
-                                  bool try_uppercase,
-                                  unsigned camel_case_limit,
-                                  CheckInfo *, CheckInfo *,
-                                  GuessInfo *);
-
     
     bool check_single(char * word, /* it WILL modify word */
                       bool try_uppercase,

--- a/modules/speller/default/speller_impl.hpp
+++ b/modules/speller/default/speller_impl.hpp
@@ -131,6 +131,13 @@ namespace aspeller {
                                   unsigned run_together_limit,
                                   CheckInfo *, CheckInfo *,
                                   GuessInfo *);
+
+    CheckInfo * check_camelcase(char * word, char * word_end, /* @kris? it WILL modify word */
+                                  bool try_uppercase,
+                                  unsigned camel_case_limit,
+                                  CheckInfo *, CheckInfo *,
+                                  GuessInfo *);
+
     
     bool check_single(char * word, /* it WILL modify word */
                       bool try_uppercase,

--- a/test/camel-case
+++ b/test/camel-case
@@ -27,12 +27,3 @@ else
     cat tmp/camel-case-res
     exit 1
 fi
-
-checkString 'thisCamelCaseStringHasWordsThatAreALLCAPSAsWell'
-if grep '^-$' tmp/camel-case-res; then
-    echo "pass"
-else
-    echo "fail:"
-    cat tmp/camel-case-res
-    exit 1
-fi

--- a/test/camel-case
+++ b/test/camel-case
@@ -3,11 +3,10 @@
 set -e
 set -x
 
-# export PATH="`pwd`"/inst/bin:$PATH
+export PATH="`pwd`"/inst/bin:$PATH
 
 checkString () {
-    #echo $1 | aspell --camel-case -a > tmp/camel-case-res
-    echo $1 | /home/kris/proj/aspell/build/aspell --camel-case -a > tmp/camel-case-res
+    echo $1 | aspell --camel-case -a > tmp/camel-case-res
 }
 
 checkString 'thisCamelCaseStringHasSevenWords'

--- a/test/camel-case
+++ b/test/camel-case
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+set -e
+set -x
+
+# export PATH="`pwd`"/inst/bin:$PATH
+
+checkString () {
+    #echo $1 | aspell --camel-case -a > tmp/camel-case-res
+    echo $1 | /home/kris/proj/aspell/build/aspell --camel-case -a > tmp/camel-case-res
+}
+
+checkString 'thisCamelCaseStringHasSevenWords'
+if grep '^-$' tmp/camel-case-res; then
+    echo "pass"
+else
+    echo "fail:"
+    cat tmp/camel-case-res
+    exit 1
+fi
+
+checkString 'thisCamelCaseStringHasMoreThanEightWords'
+if grep '^-$' tmp/camel-case-res; then
+    echo "pass"
+else
+    echo "fail:"
+    cat tmp/camel-case-res
+    exit 1
+fi
+
+checkString 'thisCamelCaseStringHasWordsThatAreALLCAPSAsWell'
+if grep '^-$' tmp/camel-case-res; then
+    echo "pass"
+else
+    echo "fail:"
+    cat tmp/camel-case-res
+    exit 1
+fi


### PR DESCRIPTION
The existing camel case limit (8) comes from the hard-coded length of `SpellerImpl::check_inf`. I changed the `check` function to no longer return  when reaching the end of the array, instead reusing the last element of the array for all subsequent checks. 

When a `CompoundInfo * cpi` is passed, reusing ci pointers means `cpi->first_incorrect` can change as well. Like the current implementation we return, setting `cpi->count` to zero.

The proposed change means we can accept large camel case words with correct spelling. Providing suggestions for incorrect spellings would require a different approach: making the `check_inf` array as well as some in `suggest.cpp`  larger (this seems to work with minimal changes) or dynamically sized.

Things I still want to look at/change:
- (re)using a placeholder object separate from the array
- factoring out a  `check_camelcase` function