### PR TITLE
PosibErr constructors: initialize data (closes GNUAspell/aspell#658)

### DIFF
--- a/common/posib_err.hpp
+++ b/common/posib_err.hpp
@@ -178,14 +178,14 @@ namespace acommon {
     PosibErr() {}
 
     PosibErr(const PosibErrBase & other) 
-      : PosibErrBase(other) {}
+      : PosibErrBase(other), data{} {}
 
     template <typename T>
     PosibErr(const PosibErr<T> & other)
       : PosibErrBase(other), data(other.data) {}
 
     PosibErr(const PosibErr<void> & other)
-      : PosibErrBase(other) {}
+      : PosibErrBase(other), data{} {}
 
     PosibErr& operator= (const PosibErr & other) {
       data = other.data;


### PR DESCRIPTION
see GNUAspell/aspell#658