### PR TITLE
Compile fixes for MSYS2 + MINGW64.

### DIFF
--- a/common/file_util.cpp
+++ b/common/file_util.cpp
@@ -30,6 +30,7 @@
 #  define ACCESS _access
 #  include <windows.h>
 #  include <winbase.h>
+#  include "asc_ctype.hpp"
 
 #else
 

--- a/common/ostream.hpp
+++ b/common/ostream.hpp
@@ -7,6 +7,8 @@
 #ifndef ASPELL_OSTREAM__HPP
 #define ASPELL_OSTREAM__HPP
 
+#define _INTL_NO_DEFINE_MACRO_PRINTF
+
 #include <stdarg.h>
 
 #include "parm_string.hpp"

--- a/modules/speller/default/language.cpp
+++ b/modules/speller/default/language.cpp
@@ -20,7 +20,7 @@
 #include "getdata.hpp"
 #include "file_util.hpp"
 
-#ifdef ENABLE_NLS
+#ifdef HAVE_LANGINFO_CODESET
 #  include <langinfo.h>
 #endif
 


### PR DESCRIPTION
From a discussion on the aspell-devel mailing list: https://lists.gnu.org/archive/html/aspell-devel/2025-05/msg00000.html

For a working binary, it is also necessary to manually specify the prefix with the absolute windows path, for example:
```
./configure '--prefix=c:/msys64/mingw64'
```
(see https://lists.gnu.org/archive/html/aspell-devel/2025-05/msg00008.html)