### PR TITLE
common/posib_err.hpp: always initalize PosibErr.data member

### DIFF
--- a/common/posib_err.hpp
+++ b/common/posib_err.hpp
@@ -175,17 +175,17 @@ namespace acommon {
   class PosibErr : public PosibErrBase
   {
   public:
-    PosibErr() {}
+    PosibErr() : data() {}
 
     PosibErr(const PosibErrBase & other) 
-      : PosibErrBase(other) {}
+      : PosibErrBase(other), data() {}
 
     template <typename T>
     PosibErr(const PosibErr<T> & other)
       : PosibErrBase(other), data(other.data) {}
 
     PosibErr(const PosibErr<void> & other)
-      : PosibErrBase(other) {}
+      : PosibErrBase(other), data() {}
 
     PosibErr& operator= (const PosibErr & other) {
       data = other.data;


### PR DESCRIPTION
closes #658
