### PR TITLE
Add po filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ Makefile
 .libs
 .dirstamp
 *.la
+.cache
+compile_commands.json
 
 # make dist generated files
 /README
@@ -57,6 +59,9 @@ Makefile
 /manual/aspell.html/
 /manual/aspell.info
 /manual/texinfo.tex
+/manual/mdate-sh
+/manual/stamp-vti
+/manual/version.texi
 /missing
 /myspell/Makefile.in
 /po/Makefile.in

--- a/Makefile.am
+++ b/Makefile.am
@@ -181,7 +181,8 @@ optfiles = \
   modules/filter/html-filter.info\
   modules/filter/context-filter.info\
   modules/filter/nroff-filter.info\
-  modules/filter/texinfo-filter.info
+  modules/filter/texinfo-filter.info\
+  modules/filter/po-filter.info
 
 ### Add all your aspell mode files ###
 fltfiles = \
@@ -196,7 +197,8 @@ fltfiles = \
   modules/filter/modes/url.amf \
   modules/filter/modes/comment.amf \
   modules/filter/modes/nroff.amf\
-  modules/filter/modes/texinfo.amf
+  modules/filter/modes/texinfo.amf \
+  modules/filter/modes/po.amf
 
 if COMPILE_IN_FILTERS
 
@@ -212,7 +214,8 @@ libaspell_la_SOURCES +=\
   modules/filter/markdown.cpp\
   modules/filter/context.cpp\
   modules/filter/nroff.cpp\
-  modules/filter/texinfo.cpp
+  modules/filter/texinfo.cpp\
+  modules/filter/po.cpp
 
 else # not COMPILE_IN_FILTERS
 
@@ -223,7 +226,7 @@ filter_ldflags = -module -avoid-version
 ### must look like lib<filtername>-filter.la see development manual
 filter_LTLIBRARIES = email-filter.la tex-filter.la\
 	             sgml-filter.la markdown-filter.la context-filter.la\
-                     nroff-filter.la texinfo-filter.la
+                     nroff-filter.la texinfo-filter.la po-filter.la
 
 email_filter_la_SOURCES = modules/filter/email.cpp
 email_filter_la_LIBADD = libaspell.la 
@@ -252,6 +255,10 @@ nroff_filter_la_LDFLAGS  = ${filter_ldflags}
 texinfo_filter_la_SOURCES  = modules/filter/texinfo.cpp
 texinfo_filter_la_LIBADD = libaspell.la
 texinfo_filter_la_LDFLAGS  = ${filter_ldflags}
+
+po_filter_la_SOURCES  = modules/filter/po.cpp
+po_filter_la_LIBADD = libaspell.la
+po_filter_la_LDFLAGS  = ${filter_ldflags}
 
 ### Before this line add the corresponding <yourfilterlibrary>_SOURCES and
 ### <yourfilterlibrary>_LIBADD lines.  The later at least has to look

--- a/manual/aspell.texi
+++ b/manual/aspell.texi
@@ -1368,6 +1368,24 @@ The Texinfo filter will also skip over the @samp{\input texinfo} line.
 
 @end table
 
+@subsubsection PO gettext Filter
+
+The @option{po} filter allows you to spell check GNU @code{gettext}
+@code{po} files. It will skip the header section, @code{msgid},
+@code{msgid_plural}, @code{msgctxt}, translator comments, extracted comments,
+references, flags and previous untranslated strings.
+
+The filter is tailored to translators. We offer an option to review the
+msgid and mssgid strings, but not the other strings.
+
+@table @b
+@item maintainer-mode
+@i{(boolean)}
+In this case, spellchecks only @code{msgid} and @code{msgid_plural}, filtering
+out any other content from the file.
+
+@end table
+
 @subsubsection Nroff Filter
 
 The @option{nroff} filter mode allows you to check the spelling of

--- a/modules/filter/modes/po.amf
+++ b/modules/filter/modes/po.amf
@@ -1,0 +1,10 @@
+MODE po
+
+ASPELL >=0.60.1
+
+MAGIC /<noregex>/po
+
+DESCRIPTION mode for checking gettext .po files
+
+FILTER url
+FILTER po

--- a/modules/filter/po-filter.info
+++ b/modules/filter/po-filter.info
@@ -1,0 +1,15 @@
+# gettext po filter option file
+
+#This Filter is usable with the following version(s) of Aspell
+ASPELL >=0.51
+
+#This line will be printed when typing `aspell help po'
+DESCRIPTION filter to deal with gettext .po files
+
+STATIC filter
+
+OPTION maintainer-mode
+TYPE bool
+DESCRIPTION review only msgids
+DEFAULT false
+ENDOPTION

--- a/modules/filter/po.cpp
+++ b/modules/filter/po.cpp
@@ -1,0 +1,283 @@
+// This file is part of The New Aspell
+// Copyright (C) 2025 by Kevin Atkinson under the GNU LGPL license
+// version 2.0 or 2.1.  You should have received a copy of the LGPL
+// license along with this library if you did not you can find
+// it at http://www.gnu.org/.
+
+#include "settings.h"
+
+#include "asc_ctype.hpp"
+#include "config.hpp"
+#include "filter_char.hpp"
+#include "indiv_filter.hpp"
+#include "iostream.hpp"
+
+// #define DEBUG_FILTER
+/*
+ * TODO://
+ *   Handle languages %placeholders initially C and Python
+ * Include the path of the directory that holds the compiled filter
+ * In an invocation like :
+ * inst/bin/aspell --add-filter-path=inst/lib/aspell-0.60/
+ * --data-dir=/usr/lib/aspell -c po/es.po To reuse the dictionaries, we need to
+ * pass the 32 bit compatibility option in Debian
+ * ./configure --enable-maintainer-mode --disable-shared
+ * --disable-pspell-compatibility   --enable-w-all-error   --prefix="`pwd`/inst"
+ * CFLAGS='-g -O' CXXFLAGS='-g -O' --enable-32-bit-hash-fun && bear -- make
+ * seergdb is an option for debugger
+ */
+using namespace acommon;
+
+namespace {
+
+enum actionState { source = 0, translation = 1, other = 2 };
+
+class PoFilter : public IndividualFilter {
+  int hide_to_char(FilterChar *, char, FilterChar *);
+  int find_char(FilterChar *, char, FilterChar *);
+  int hide_all(FilterChar *, FilterChar *);
+  int initial_whitespace(FilterChar *, FilterChar *);
+  int sanitize_portion(FilterChar *, FilterChar *);
+  void maintainer(FilterChar *&, FilterChar *&);
+  void translator(FilterChar *&, FilterChar *&);
+
+public:
+  virtual PosibErr<bool> setup(Config *);
+  virtual void reset(void);
+  void process(FilterChar *&, FilterChar *&);
+};
+
+bool in_header = false;
+bool header_processed = false;
+bool in_translation = false;
+bool maintainer_mode = false;
+actionState current_action = other;
+
+PosibErr<bool> PoFilter::setup(Config *config) {
+  name_ = "po-filter";
+  order_num_ = 0.80;
+
+  maintainer_mode = config->retrieve_bool("f-po-maintainer-mode");
+  return true;
+}
+
+void PoFilter::maintainer(FilterChar *&str, FilterChar *&end) {
+
+  for (FilterChar *cur = str; cur < end;) {
+    if (*cur == 'm' && *(cur + 1) == 's' && *(cur + 2) == 'g' &&
+        *(cur + 3) == 'i' && *(cur + 4) == 'd') {
+      current_action = source;
+      cur += hide_to_char(cur, '"', end);
+      if (cur >= end)
+        break;
+      sanitize_portion(cur, end - 2);
+      cur += find_char(cur, '\n', end);
+      if (*(cur - 2) == '"')
+        *(cur - 2) = ' ';
+    } else {
+      if (current_action == source) {
+        cur += initial_whitespace(cur, end);
+        if (*cur == '"') {
+          // This is a multiline msgid...
+          *cur = ' ';
+          sanitize_portion(cur + 1, end - 1);
+          if (*(end - 1) == '"')
+            *(end - 1) = ' ';
+          cur = end;
+          break;
+        } else {
+          current_action = other;
+        }
+      }
+      cur += hide_to_char(cur, '\n', end);
+    }
+  }
+}
+
+void PoFilter::translator(FilterChar *&str, FilterChar *&end) {
+  for (FilterChar *cur = str; cur < end;) {
+    if (*cur == 'm' && *(cur + 1) == 's' && *(cur + 2) == 'g' &&
+        cur + 6 < end) {
+      cur += hide_all(cur, cur + 3);
+      current_action = other;
+      if (*cur == 'i' && *(cur + 1) == 'd' && header_processed == false) {
+        current_action = source;
+        in_translation = false;
+        cur += hide_to_char(cur, '"', end);
+        if (cur >= end)
+          break;
+        in_header = *cur == '"';
+#ifdef DEBUG_FILTER
+        if (in_header) {
+          CERR.printf(" H");
+        } else {
+          CERR.printf(" h");
+        }
+#endif
+        cur += hide_to_char(cur, '\n', end);
+        if (cur >= end)
+          break;
+      } else if (*cur == 's' && *(cur + 1) == 't' && *(cur + 2) == 'r') {
+        current_action = translation;
+        if (in_header) {
+#ifdef DEBUG_FILTER
+          CERR.printf(" H");
+#endif
+          in_translation = false;
+          cur += hide_all(cur, end);
+          break;
+        } else {
+          in_translation = true;
+        }
+        cur += hide_to_char(cur, '"', end);
+        if (cur >= end)
+          break;
+#ifdef DEBUG_FILTER
+        if (end > cur + 1) {
+          CERR.printf(" I -----------------------");
+        }
+#endif
+        // the chunk between cur and end is the translation
+        // and can be processed to avoid escape characters
+        // and ignore formatters or the like for a given language
+        sanitize_portion(cur, end - 2);
+        cur += find_char(cur, '\n', end);
+        if (*(cur - 2) == '"')
+          *(cur - 2) = ' ';
+      } else { // A malformed file is not reviewed
+        in_translation = false;
+        cur += hide_all(cur, end);
+      }
+    } else {
+      if (in_translation) {
+        cur += initial_whitespace(cur, end);
+        if (*cur == '"') {
+          // This is a multiline translation
+#ifdef DEBUG_FILTER
+          CERR.printf(" M -----------------------");
+#endif
+          *cur = ' ';
+          sanitize_portion(cur + 1, end - 1);
+          if (*(end - 1) == '"')
+            *(end - 1) = ' ';
+          cur = end;
+          break;
+        }
+#ifdef DEBUG_FILTER
+        CERR.printf(" h");
+#endif
+        in_translation = false;
+        // The line does not start with a quote, then hiding
+        cur += hide_all(cur, end);
+      } else {
+        if (current_action == source) {
+          in_header = false;
+        }
+        in_translation = false;
+        cur += hide_all(cur, end);
+#ifdef DEBUG_FILTER
+        CERR.printf(" h");
+#endif
+      }
+    }
+  } // end of for
+}
+
+void PoFilter::process(FilterChar *&str, FilterChar *&end) {
+#ifdef DEBUG_FILTER
+  CERR.printf("\np %lu:", end - str);
+  FilterChar *tmp = str;
+  int limit = 20, i = 0;
+  while (tmp < end - 1 && i < limit) {
+    CERR.printf("%c", (char)*tmp);
+    tmp++;
+    i++;
+  }
+#endif
+  if (maintainer_mode) {
+    maintainer(str, end);
+  } else {
+    translator(str, end);
+  }
+}
+
+int PoFilter::hide_all(FilterChar *begin, FilterChar *end) {
+  // We will hide everything, nothing to work in here
+  FilterChar *current = begin;
+
+  while (current < end) {
+    *current = ' ';
+    current++;
+  }
+  return current - begin;
+}
+
+int PoFilter::hide_to_char(FilterChar *begin, char limiter, FilterChar *end) {
+  // This line needs no spell checking, we go out if the endline is
+  // reached, and do no clear the endline, otherwise we clear
+  FilterChar *current = begin;
+  while (current < end) {
+    if (*current == '\n') {
+      current++;
+      break;
+    } else if (*current == limiter) {
+      *current = ' ';
+      current++;
+      break;
+    }
+    *current = ' ';
+    current++;
+  }
+  return current - begin;
+}
+
+int PoFilter::find_char(FilterChar *begin, char limiter, FilterChar *end) {
+  // We find the limiter and return the position of the next char
+  // we are limited also by the line
+  FilterChar *current = begin;
+  while (current < end) {
+    if (*current == limiter || *current == '\n') {
+      current++;
+      break;
+    }
+    current++;
+  }
+  return current - begin;
+}
+
+int PoFilter::initial_whitespace(FilterChar *begin, FilterChar *end) {
+  // We find the limiter and return the position of the next char
+  FilterChar *current = begin;
+  while (current < end && asc_isspace(*current))
+    current++;
+  return current - begin;
+}
+
+int PoFilter::sanitize_portion(FilterChar *begin, FilterChar *end) {
+  // We remove the escape characters like \n and friends
+  FilterChar *current = begin;
+  while (current < end) {
+    if (*current == '\\') {
+      *current = ' ';
+      current++;
+      if (current < end) {
+        *current = ' ';
+        current++;
+      } else {
+        break;
+      }
+    }
+    current++;
+  }
+  return current - begin;
+}
+
+void PoFilter::reset(void) {
+  in_header = false;
+  header_processed = false;
+  maintainer_mode = false;
+}
+} // namespace
+
+C_EXPORT
+IndividualFilter *new_aspell_po_filter() { return new PoFilter; }

--- a/po/aspell.pot
+++ b/po/aspell.pot
@@ -1,6 +1,6 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Kevin Atkinson
-# This file is distributed under the same license as the PACKAGE package.
+# This file is distributed under the same license as the aspell package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 #, fuzzy
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aspell 0.60.9-git\n"
 "Report-Msgid-Bugs-To: kevina@gnu.org\n"
-"POT-Creation-Date: 2023-12-19 16:19-0500\n"
+"POT-Creation-Date: 2025-06-16 20:23-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -440,7 +440,6 @@ msgid "The key \"%key:1\" does not take any parameters when prefixed by a \"clea
 msgstr ""
 
 #: common/errors.cpp:235
-#, c-format
 msgid "The language \"%lang:1\" is not known."
 msgstr ""
 
@@ -450,17 +449,14 @@ msgid "The soundslike \"%sl:2\" is not known."
 msgstr ""
 
 #: common/errors.cpp:251
-#, c-format
 msgid "The language \"%lang:1\" is not supported."
 msgstr ""
 
 #: common/errors.cpp:259
-#, c-format
 msgid "No word lists can be found for the language \"%lang:1\"."
 msgstr ""
 
 #: common/errors.cpp:267
-#, c-format
 msgid "Expected language \"%lang:1\" but got \"%prev:2\"."
 msgstr ""
 
@@ -1262,6 +1258,14 @@ msgstr ""
 msgid "filter for dealing with Nroff documents"
 msgstr ""
 
+#: modules/filter/po-filter.info:7
+msgid "filter to deal with gettext .po files"
+msgstr ""
+
+#: modules/filter/po-filter.info:13
+msgid "review only msgids"
+msgstr ""
+
 #: modules/filter/sgml-filter.info:9
 msgid "filter for dealing with generic SGML/XML documents"
 msgstr ""
@@ -1332,6 +1336,10 @@ msgstr ""
 
 #: modules/filter/modes/perl.amf:8
 msgid "mode for checking Perl comments and string literals"
+msgstr ""
+
+#: modules/filter/modes/po.amf:7
+msgid "mode for checking gettext .po files"
 msgstr ""
 
 #: modules/filter/modes/sgml.amf:8

--- a/po/ast.po
+++ b/po/ast.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aspell 0.60.6\n"
 "Report-Msgid-Bugs-To: kevina@gnu.org\n"
-"POT-Creation-Date: 2023-12-19 16:19-0500\n"
+"POT-Creation-Date: 2025-06-16 20:23-0500\n"
 "PO-Revision-Date: 2010-02-28 22:09+0200\n"
 "Last-Translator: Marquinos <maacub@gmail.com>\n"
 "Language-Team: Asturian <ubuntu-l10n-ast@lists.ubuntu.com>\n"
@@ -451,7 +451,6 @@ msgid "The key \"%key:1\" does not take any parameters when prefixed by a \"clea
 msgstr "La clave «%key:1» nun almite parámetros cuando lleva'l prefixu «clear-»."
 
 #: common/errors.cpp:235
-#, c-format
 msgid "The language \"%lang:1\" is not known."
 msgstr "Nun se conoz l'idioma «%lang:1»."
 
@@ -461,17 +460,14 @@ msgid "The soundslike \"%sl:2\" is not known."
 msgstr "Nun se conoz l'asemeyanza fonética «%sl:2»."
 
 #: common/errors.cpp:251
-#, c-format
 msgid "The language \"%lang:1\" is not supported."
 msgstr "Nun se soporta l'idioma «%lang:1»."
 
 #: common/errors.cpp:259
-#, c-format
 msgid "No word lists can be found for the language \"%lang:1\"."
 msgstr "Nun s'atoparon pallabreros pal idioma «%lang:1»."
 
 #: common/errors.cpp:267
-#, c-format
 msgid "Expected language \"%lang:1\" but got \"%prev:2\"."
 msgstr "Esperábase l'idioma «%lang:1» pero atopóse «%prev:2»."
 
@@ -1303,6 +1299,16 @@ msgstr ""
 msgid "filter for dealing with Nroff documents"
 msgstr "filtru pa remanar documentos Nroff"
 
+#: modules/filter/po-filter.info:7
+#, fuzzy
+#| msgid "filter for dealing with Texinfo documents"
+msgid "filter to deal with gettext .po files"
+msgstr "filtru pa remanar documentos Texinfo"
+
+#: modules/filter/po-filter.info:13
+msgid "review only msgids"
+msgstr ""
+
 #: modules/filter/sgml-filter.info:9
 msgid "filter for dealing with generic SGML/XML documents"
 msgstr "filtru pa remanar documentos SGML/XML"
@@ -1376,6 +1382,12 @@ msgstr "mou pa comprobar documentos Nroff"
 #: modules/filter/modes/perl.amf:8
 msgid "mode for checking Perl comments and string literals"
 msgstr "mou pa comprobar comentarios Perl y lliterales de cadenes"
+
+#: modules/filter/modes/po.amf:7
+#, fuzzy
+#| msgid "mode for checking Texinfo documents"
+msgid "mode for checking gettext .po files"
+msgstr "mou pa comprobar documentos Texinfo"
 
 #: modules/filter/modes/sgml.amf:8
 msgid "mode for checking generic SGML/XML documents"

--- a/po/be.po
+++ b/po/be.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aspell 0.51\n"
 "Report-Msgid-Bugs-To: kevina@gnu.org\n"
-"POT-Creation-Date: 2023-12-19 16:19-0500\n"
+"POT-Creation-Date: 2025-06-16 20:23-0500\n"
 "PO-Revision-Date: 2004-01-06 16:34+0200\n"
 "Last-Translator: Vital khilko <dojlid@mova.org>\n"
 "Language-Team: Belarusian <i18n@mova.org>\n"
@@ -476,7 +476,6 @@ msgid "The key \"%key:1\" does not take any parameters when prefixed by a \"clea
 msgstr ""
 
 #: common/errors.cpp:235
-#, c-format
 msgid "The language \"%lang:1\" is not known."
 msgstr "Мова \"%lang:1\" невядома."
 
@@ -486,17 +485,14 @@ msgid "The soundslike \"%sl:2\" is not known."
 msgstr "Невядомы гук \"%sl:2\"."
 
 #: common/errors.cpp:251
-#, c-format
 msgid "The language \"%lang:1\" is not supported."
 msgstr "Мова \"%lang:1\" не падтрымліваецца."
 
 #: common/errors.cpp:259
-#, c-format
 msgid "No word lists can be found for the language \"%lang:1\"."
 msgstr "Няма сьпісу словаў для мовы \"%lang:1\"."
 
 #: common/errors.cpp:267
-#, c-format
 msgid "Expected language \"%lang:1\" but got \"%prev:2\"."
 msgstr "Чакалася мова \"%lang:1\" але атрымана \"%prev:2\"."
 
@@ -1353,6 +1349,16 @@ msgstr ""
 msgid "filter for dealing with Nroff documents"
 msgstr ""
 
+#: modules/filter/po-filter.info:7
+#, fuzzy
+#| msgid "Filter for recognizing TeX/LaTeX commands"
+msgid "filter to deal with gettext .po files"
+msgstr "Фільтар для вызначэньня камандаў TeX/LaTeX"
+
+#: modules/filter/po-filter.info:13
+msgid "review only msgids"
+msgstr ""
+
 #: modules/filter/sgml-filter.info:9
 msgid "filter for dealing with generic SGML/XML documents"
 msgstr ""
@@ -1432,6 +1438,12 @@ msgstr ""
 #: modules/filter/modes/perl.amf:8
 msgid "mode for checking Perl comments and string literals"
 msgstr ""
+
+#: modules/filter/modes/po.amf:7
+#, fuzzy
+#| msgid "Filter for recognizing TeX/LaTeX commands"
+msgid "mode for checking gettext .po files"
+msgstr "Фільтар для вызначэньня камандаў TeX/LaTeX"
 
 #: modules/filter/modes/sgml.amf:8
 msgid "mode for checking generic SGML/XML documents"

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aspell 0.60.3\n"
 "Report-Msgid-Bugs-To: kevina@gnu.org\n"
-"POT-Creation-Date: 2023-12-19 16:19-0500\n"
+"POT-Creation-Date: 2025-06-16 20:23-0500\n"
 "PO-Revision-Date: 2006-07-03 19:40+0100\n"
 "Last-Translator: Joan Sala Soler <joansala@gmail.com>\n"
 "Language-Team: Catalan <ca@dodds.net>\n"
@@ -452,7 +452,6 @@ msgid "The key \"%key:1\" does not take any parameters when prefixed by a \"clea
 msgstr "La clau «%key:1» no admet cap paràmetre quan es prefixa amb «clear-»."
 
 #: common/errors.cpp:235
-#, c-format
 msgid "The language \"%lang:1\" is not known."
 msgstr "Es desconeix l’idioma «%lang:1»."
 
@@ -462,17 +461,14 @@ msgid "The soundslike \"%sl:2\" is not known."
 msgstr "Es desconeix la semblança fònica «%sl:2»."
 
 #: common/errors.cpp:251
-#, c-format
 msgid "The language \"%lang:1\" is not supported."
 msgstr "L’idioma «%lang:1» no està implementat."
 
 #: common/errors.cpp:259
-#, c-format
 msgid "No word lists can be found for the language \"%lang:1\"."
 msgstr "No s’ha pogut trobar cap vocabulari per a l’idioma «%lang:1»."
 
 #: common/errors.cpp:267
-#, c-format
 msgid "Expected language \"%lang:1\" but got \"%prev:2\"."
 msgstr "S’esperava l’idioma «%lang:1», però s’ha trobat «%prev:2»."
 
@@ -1305,6 +1301,16 @@ msgstr ""
 msgid "filter for dealing with Nroff documents"
 msgstr "filtre per a ocupar-se dels documents Nroff"
 
+#: modules/filter/po-filter.info:7
+#, fuzzy
+#| msgid "filter for dealing with Texinfo documents"
+msgid "filter to deal with gettext .po files"
+msgstr "filtre per a ocupar-se dels documents Texinfo"
+
+#: modules/filter/po-filter.info:13
+msgid "review only msgids"
+msgstr ""
+
 #: modules/filter/sgml-filter.info:9
 msgid "filter for dealing with generic SGML/XML documents"
 msgstr "filtre per a ocupar-se dels documents SGML/XML"
@@ -1378,6 +1384,12 @@ msgstr "mode de revisió de documents Nroff"
 #: modules/filter/modes/perl.amf:8
 msgid "mode for checking Perl comments and string literals"
 msgstr "mode de revisió de comentaris i literals Perl"
+
+#: modules/filter/modes/po.amf:7
+#, fuzzy
+#| msgid "mode for checking Texinfo documents"
+msgid "mode for checking gettext .po files"
+msgstr "mode de revisió de documents Texinfo"
 
 #: modules/filter/modes/sgml.amf:8
 msgid "mode for checking generic SGML/XML documents"

--- a/po/cs.po
+++ b/po/cs.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aspell 0.60.8-pre2\n"
 "Report-Msgid-Bugs-To: kevina@gnu.org\n"
-"POT-Creation-Date: 2019-09-24 03:02-0400\n"
+"POT-Creation-Date: 2025-06-16 20:23-0500\n"
 "PO-Revision-Date: 2020-04-06 10:41+0200\n"
 "Last-Translator: Branislav Makúch <makuch@disroot.org>\n"
 "Language-Team: Czech <translation-team-cs@lists.sourceforge.net>\n"
@@ -454,7 +454,6 @@ msgid "The key \"%key:1\" does not take any parameters when prefixed by a \"clea
 msgstr "Klíč „%key:1“ nemá žádné parametry, když má předponu „clear-“."
 
 #: common/errors.cpp:235
-#, c-format
 msgid "The language \"%lang:1\" is not known."
 msgstr "Jazyk „%lang:1“ není znám."
 
@@ -464,17 +463,14 @@ msgid "The soundslike \"%sl:2\" is not known."
 msgstr "Podobnost zvuku „%sl:2“ není známa."
 
 #: common/errors.cpp:251
-#, c-format
 msgid "The language \"%lang:1\" is not supported."
 msgstr "Jazyk „%lang:1“ není podporován."
 
 #: common/errors.cpp:259
-#, c-format
 msgid "No word lists can be found for the language \"%lang:1\"."
 msgstr "Pro jazyk „%lang:1“ nelze najít seznam slov."
 
 #: common/errors.cpp:267
-#, c-format
 msgid "Expected language \"%lang:1\" but got \"%prev:2\"."
 msgstr "Byl očekáván jazyk „%lang:1“, ale obdržen „%prev:2“."
 
@@ -685,7 +681,9 @@ msgid "Invalid Option: %s"
 msgstr "Neplatný přepínač: %s"
 
 #: prog/aspell.cpp:322
-msgid " does not take any parameters."
+#, fuzzy, c-format
+#| msgid " does not take any parameters."
+msgid "'%s' does not take any parameters."
 msgstr " nemá žádné parametry."
 
 #: prog/aspell.cpp:335 prog/aspell.cpp:395
@@ -942,10 +940,14 @@ msgid "  <norm-form>      normalization form to use, either none, internal, or s
 msgstr "  <norm-forma>     normalizační forma, buď none, internal nebo strict"
 
 #: prog/aspell.cpp:2884
-#, c-format
+#, fuzzy, c-format
+#| msgid ""
+#| "\n"
+#| "Aspell %s.  Copyright 2000-2019 by Kevin Atkinson.\n"
+#| "\n"
 msgid ""
 "\n"
-"Aspell %s.  Copyright 2000-2019 by Kevin Atkinson.\n"
+"Aspell %s.  Copyright 2000-2023 by Kevin Atkinson.\n"
 "\n"
 msgstr ""
 "\n"
@@ -1211,7 +1213,7 @@ msgid "There must be at least one \"add\" line."
 msgstr "Musí existovat aspoň jeden řádek „add“."
 
 # must "ultra" "fast" "slow" and "bad-spellers" not be translated?
-#: modules/speller/default/suggest.cpp:1720
+#: modules/speller/default/suggest.cpp:1730
 msgid "one of ultra, fast, normal, slow, or bad-spellers"
 msgstr "jedno z ultra, fast, normal, slow nebo bad-spellers"
 
@@ -1298,6 +1300,16 @@ msgstr "Tagy HTML zahajující blok HTML, který končí prázdným řádkem"
 msgid "filter for dealing with Nroff documents"
 msgstr "filtr pro práci s dokumenty Nroff"
 
+#: modules/filter/po-filter.info:7
+#, fuzzy
+#| msgid "filter for dealing with Texinfo documents"
+msgid "filter to deal with gettext .po files"
+msgstr "filtr pro práci s dokumenty Texinfo"
+
+#: modules/filter/po-filter.info:13
+msgid "review only msgids"
+msgstr ""
+
 #: modules/filter/sgml-filter.info:9
 msgid "filter for dealing with generic SGML/XML documents"
 msgstr "filtr pro práci s obecnými dokumenty SGML/XML"
@@ -1369,6 +1381,12 @@ msgstr "režim pro kontrolu dokumentů Nroff"
 #: modules/filter/modes/perl.amf:8
 msgid "mode for checking Perl comments and string literals"
 msgstr "režim pro kontrolu komentářů a řetězcových literálů v Perlu"
+
+#: modules/filter/modes/po.amf:7
+#, fuzzy
+#| msgid "mode for checking Texinfo documents"
+msgid "mode for checking gettext .po files"
+msgstr "režim pro kontrolu dokumentů Texinfo"
 
 #: modules/filter/modes/sgml.amf:8
 msgid "mode for checking generic SGML/XML documents"

--- a/po/da.po
+++ b/po/da.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aspell 0.60.8-pre2\n"
 "Report-Msgid-Bugs-To: kevina@gnu.org\n"
-"POT-Creation-Date: 2019-09-24 03:02-0400\n"
+"POT-Creation-Date: 2025-06-16 20:23-0500\n"
 "PO-Revision-Date: 2020-03-08 12:51+0200\n"
 "Last-Translator: Joe Hansen <joedalton2@yahoo.dk>\n"
 "Language-Team: Danish <dansk@dansk-gruppen.dk>\n"
@@ -461,7 +461,6 @@ msgid "The key \"%key:1\" does not take any parameters when prefixed by a \"clea
 msgstr "Nøglen »%key:1« tager ikke nogle parametre, når den er foranstillet med »clear-«."
 
 #: common/errors.cpp:235
-#, c-format
 msgid "The language \"%lang:1\" is not known."
 msgstr "Sproget »%lang:1« er ukendt."
 
@@ -471,17 +470,14 @@ msgid "The soundslike \"%sl:2\" is not known."
 msgstr "soundslikereglerne (udtale) »%sl:2« er ukendte."
 
 #: common/errors.cpp:251
-#, c-format
 msgid "The language \"%lang:1\" is not supported."
 msgstr "Kan ikke håndtere sproget »%lang:1«."
 
 #: common/errors.cpp:259
-#, c-format
 msgid "No word lists can be found for the language \"%lang:1\"."
 msgstr "Kan ikke finde nogle ordlister for sproget »%lang:1«."
 
 #: common/errors.cpp:267
-#, c-format
 msgid "Expected language \"%lang:1\" but got \"%prev:2\"."
 msgstr "Forventede sproget »%lang:1«, men fandt »%prev:2«."
 
@@ -692,7 +688,9 @@ msgid "Invalid Option: %s"
 msgstr "Ugyldigt tilvalg: %s"
 
 #: prog/aspell.cpp:322
-msgid " does not take any parameters."
+#, fuzzy, c-format
+#| msgid " does not take any parameters."
+msgid "'%s' does not take any parameters."
 msgstr " tager ikke nogle argumenter."
 
 #: prog/aspell.cpp:335 prog/aspell.cpp:395
@@ -945,10 +943,14 @@ msgid "  <norm-form>      normalization form to use, either none, internal, or s
 msgstr "  <norm-form>      normaliseringsform der skal bruges, enten none, internal eller strict"
 
 #: prog/aspell.cpp:2884
-#, c-format
+#, fuzzy, c-format
+#| msgid ""
+#| "\n"
+#| "Aspell %s.  Copyright 2000-2019 by Kevin Atkinson.\n"
+#| "\n"
 msgid ""
 "\n"
-"Aspell %s.  Copyright 2000-2019 by Kevin Atkinson.\n"
+"Aspell %s.  Copyright 2000-2023 by Kevin Atkinson.\n"
 "\n"
 msgstr ""
 "\n"
@@ -1212,7 +1214,7 @@ msgstr "Den totale ordlængde, med soundslike (udtale) data, er længere end 240
 msgid "There must be at least one \"add\" line."
 msgstr "Der skal mindst være en »tilføj linje«."
 
-#: modules/speller/default/suggest.cpp:1720
+#: modules/speller/default/suggest.cpp:1730
 msgid "one of ultra, fast, normal, slow, or bad-spellers"
 msgstr "en af ultra, hurtig, normal, langsom eller dårlig stavning"
 
@@ -1299,6 +1301,16 @@ msgstr "HTML-mærker der starter en HTML-blok, der slutter med en tom linje"
 msgid "filter for dealing with Nroff documents"
 msgstr "filter til at håndtere Nroff-dokumenter"
 
+#: modules/filter/po-filter.info:7
+#, fuzzy
+#| msgid "filter for dealing with Texinfo documents"
+msgid "filter to deal with gettext .po files"
+msgstr "Filter til at håndtere Texinfo-dokumenter"
+
+#: modules/filter/po-filter.info:13
+msgid "review only msgids"
+msgstr ""
+
 #: modules/filter/sgml-filter.info:9
 msgid "filter for dealing with generic SGML/XML documents"
 msgstr "filter til at håndtere generiske SGML-/XML-dokumenter"
@@ -1370,6 +1382,12 @@ msgstr "tilstand for tjek af Nroff-dokumenter"
 #: modules/filter/modes/perl.amf:8
 msgid "mode for checking Perl comments and string literals"
 msgstr "tilstand for tjek af Perl-kommentarer og slåfejl i strenge"
+
+#: modules/filter/modes/po.amf:7
+#, fuzzy
+#| msgid "mode for checking Texinfo documents"
+msgid "mode for checking gettext .po files"
+msgstr "tilstand for at tjekke Texinfo-dokumenter"
 
 #: modules/filter/modes/sgml.amf:8
 msgid "mode for checking generic SGML/XML documents"

--- a/po/de.po
+++ b/po/de.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aspell 0.60.8.1\n"
 "Report-Msgid-Bugs-To: kevina@gnu.org\n"
-"POT-Creation-Date: 2023-12-03 01:21-0500\n"
+"POT-Creation-Date: 2025-06-16 20:23-0500\n"
 "PO-Revision-Date: 2023-12-19 19:16+0100\n"
 "Last-Translator: Roland Illig <roland.illig@gmx.de>\n"
 "Language-Team: German <translation-team-de@lists.sourceforge.net>\n"
@@ -451,7 +451,6 @@ msgid "The key \"%key:1\" does not take any parameters when prefixed by a \"clea
 msgstr "Der Schlüssel »%key:1« kann keine Parameter haben, wenn ein »clear-« vorangestellt ist."
 
 #: common/errors.cpp:235
-#, c-format
 msgid "The language \"%lang:1\" is not known."
 msgstr "Die Sprache »%lang:1« ist unbekannt."
 
@@ -461,17 +460,14 @@ msgid "The soundslike \"%sl:2\" is not known."
 msgstr "Der Wortklang »%sl:2« ist nicht bekannt."
 
 #: common/errors.cpp:251
-#, c-format
 msgid "The language \"%lang:1\" is not supported."
 msgstr "Die Sprache »%lang:1« wird nicht unterstützt."
 
 #: common/errors.cpp:259
-#, c-format
 msgid "No word lists can be found for the language \"%lang:1\"."
 msgstr "Für die Sprache »%lang:1« können keine Wortlisten gefunden werden."
 
 #: common/errors.cpp:267
-#, c-format
 msgid "Expected language \"%lang:1\" but got \"%prev:2\"."
 msgstr "Sprache »%lang:1« erwartet, aber »%prev:2« bekommen."
 
@@ -1291,6 +1287,16 @@ msgstr "HTML-Tags, die einen HTML-Block beginnen, der mit einer Leerzeile endet"
 msgid "filter for dealing with Nroff documents"
 msgstr "Filter, um nroff-Dokumente zu behandeln"
 
+#: modules/filter/po-filter.info:7
+#, fuzzy
+#| msgid "filter for dealing with Texinfo documents"
+msgid "filter to deal with gettext .po files"
+msgstr "Filter, um Texinfo-Dokumente zu behandeln"
+
+#: modules/filter/po-filter.info:13
+msgid "review only msgids"
+msgstr ""
+
 #: modules/filter/sgml-filter.info:9
 msgid "filter for dealing with generic SGML/XML documents"
 msgstr "Filter, um generische SGML/XML-Dokumente zu behandeln"
@@ -1362,6 +1368,12 @@ msgstr "Modus, um nroff-Dokumente zu überprüfen"
 #: modules/filter/modes/perl.amf:8
 msgid "mode for checking Perl comments and string literals"
 msgstr "Modus, um Perl-Kommentare und Zeichenkettenliterale zu überprüfen"
+
+#: modules/filter/modes/po.amf:7
+#, fuzzy
+#| msgid "mode for checking Texinfo documents"
+msgid "mode for checking gettext .po files"
+msgstr "Modus, um Texinfo-Dokumente zu überprüfen"
 
 #: modules/filter/modes/sgml.amf:8
 msgid "mode for checking generic SGML/XML documents"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aspell 0.60-pre1\n"
 "Report-Msgid-Bugs-To: kevina@gnu.org\n"
-"POT-Creation-Date: 2023-12-19 16:19-0500\n"
+"POT-Creation-Date: 2025-06-16 20:23-0500\n"
 "PO-Revision-Date: 2004-07-25 19:46-0400\n"
 "Last-Translator: Gareth Owen <gowen72@yahoo.com>\n"
 "Language-Team: English (British) <en_gb@li.org>\n"
@@ -454,7 +454,6 @@ msgid "The key \"%key:1\" does not take any parameters when prefixed by a \"clea
 msgstr "The key \"%key:1\" does not take any parameters when prefixed by a \"clear-\"."
 
 #: common/errors.cpp:235
-#, c-format
 msgid "The language \"%lang:1\" is not known."
 msgstr "The language \"%lang:1\" is not known."
 
@@ -464,17 +463,14 @@ msgid "The soundslike \"%sl:2\" is not known."
 msgstr "The soundslike \"%sl:2\" is not known."
 
 #: common/errors.cpp:251
-#, c-format
 msgid "The language \"%lang:1\" is not supported."
 msgstr "The language \"%lang:1\" is not supported."
 
 #: common/errors.cpp:259
-#, c-format
 msgid "No word lists can be found for the language \"%lang:1\"."
 msgstr "No word lists can be found for the language \"%lang:1\"."
 
 #: common/errors.cpp:267
-#, c-format
 msgid "Expected language \"%lang:1\" but got \"%prev:2\"."
 msgstr "Expected language \"%lang:1\" but got \"%prev:2\"."
 
@@ -1314,6 +1310,16 @@ msgstr ""
 msgid "filter for dealing with Nroff documents"
 msgstr "filter for dealing with HTML documents"
 
+#: modules/filter/po-filter.info:7
+#, fuzzy
+#| msgid "filter for dealing with HTML documents"
+msgid "filter to deal with gettext .po files"
+msgstr "filter for dealing with HTML documents"
+
+#: modules/filter/po-filter.info:13
+msgid "review only msgids"
+msgstr ""
+
 #: modules/filter/sgml-filter.info:9
 msgid "filter for dealing with generic SGML/XML documents"
 msgstr "filter for dealing with generic SGML/XML documents"
@@ -1395,6 +1401,12 @@ msgstr "mode for checking HTML documents"
 #| msgid "mode for checking perl comments and string literals"
 msgid "mode for checking Perl comments and string literals"
 msgstr "mode for checking perl comments and string literals"
+
+#: modules/filter/modes/po.amf:7
+#, fuzzy
+#| msgid "mode for checking HTML documents"
+msgid "mode for checking gettext .po files"
+msgstr "mode for checking HTML documents"
 
 #: modules/filter/modes/sgml.amf:8
 msgid "mode for checking generic SGML/XML documents"

--- a/po/eo.po
+++ b/po/eo.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aspell 0.60.8.1\n"
 "Report-Msgid-Bugs-To: kevina@gnu.org\n"
-"POT-Creation-Date: 2023-12-03 01:21-0500\n"
+"POT-Creation-Date: 2025-06-16 20:23-0500\n"
 "PO-Revision-Date: 2023-12-12 10:02-0500\n"
 "Last-Translator: Felipe Castro <fefcas@gmail.com>\n"
 "Language-Team: Esperanto <translation-team-eo@lists.sourceforge.net>\n"
@@ -450,7 +450,6 @@ msgid "The key \"%key:1\" does not take any parameters when prefixed by a \"clea
 msgstr "La ŝlosilo \"%key:1\" ne prenas iun ajn parametron kiam prefiksita de \"clear-\"."
 
 #: common/errors.cpp:235
-#, c-format
 msgid "The language \"%lang:1\" is not known."
 msgstr "La lingvo \"%lang:1\" ne estas konata."
 
@@ -460,17 +459,14 @@ msgid "The soundslike \"%sl:2\" is not known."
 msgstr "La fonemo \"%sl:2\" ne estas konata."
 
 #: common/errors.cpp:251
-#, c-format
 msgid "The language \"%lang:1\" is not supported."
 msgstr "La lingvo \"%lang:1\" ne estas subtenata."
 
 #: common/errors.cpp:259
-#, c-format
 msgid "No word lists can be found for the language \"%lang:1\"."
 msgstr "Neniu vortlisto povas esti trovata por la lingvo \"%lang:1\"."
 
 #: common/errors.cpp:267
-#, c-format
 msgid "Expected language \"%lang:1\" but got \"%prev:2\"."
 msgstr "Ni atendis la lingvon \"%lang:1\" sed ni ricevis \"%prev:2\"."
 
@@ -1288,6 +1284,16 @@ msgstr "HTML-etikedoj kiuj komencigas HTML-blokon kiuj finas per blank-linio"
 msgid "filter for dealing with Nroff documents"
 msgstr "filtrilo por trakti dokumentojn Nroff"
 
+#: modules/filter/po-filter.info:7
+#, fuzzy
+#| msgid "filter for dealing with Texinfo documents"
+msgid "filter to deal with gettext .po files"
+msgstr "filtrilo por trakti dokumentojn Texinfo"
+
+#: modules/filter/po-filter.info:13
+msgid "review only msgids"
+msgstr ""
+
 #: modules/filter/sgml-filter.info:9
 msgid "filter for dealing with generic SGML/XML documents"
 msgstr "filtrilo por trakti ĝeneralan dokumenton SGML/XML"
@@ -1359,6 +1365,12 @@ msgstr "reĝimo por kontroli dokumentojn Nroff"
 #: modules/filter/modes/perl.amf:8
 msgid "mode for checking Perl comments and string literals"
 msgstr "reĝimo por kontroli komentojn Perl & ĉenliteraĵojn"
+
+#: modules/filter/modes/po.amf:7
+#, fuzzy
+#| msgid "mode for checking Texinfo documents"
+msgid "mode for checking gettext .po files"
+msgstr "reĝimo por kontroli dokumentojn Texinfo"
 
 #: modules/filter/modes/sgml.amf:8
 msgid "mode for checking generic SGML/XML documents"

--- a/po/es.po
+++ b/po/es.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aspell 0.60.8-pre2\n"
 "Report-Msgid-Bugs-To: kevina@gnu.org\n"
-"POT-Creation-Date: 2019-09-24 03:02-0400\n"
+"POT-Creation-Date: 2025-06-16 20:20-0500\n"
 "PO-Revision-Date: 2022-01-27 09:12-0600\n"
 "Last-Translator: Alejandro Cendejas Tena <alex.cendejas@gmail.com>\n"
 "Language-Team: Spanish <es@tp.org.es>\n"
@@ -24,7 +24,7 @@ msgstr ""
 
 #: common/info.cpp:232
 msgid "a number between 0 and 1"
-msgstr "un número entre 0 y 1"
+msgstr "un nÃºmero entre 0 y 1"
 
 #: common/info.cpp:569
 msgid "in the form \"<name> <value>\""
@@ -90,15 +90,15 @@ msgstr "variable de entorno ASPELL_CONF"
 #. include any trailing punctuation marks.
 #: common/config.cpp:1380
 msgid "main configuration file"
-msgstr "archivo de configuración principal"
+msgstr "archivo principal de configuraciÃ³n"
 
 #: common/config.cpp:1382
 msgid "location of main configuration file"
-msgstr "ubicación del archivo de configuración principal"
+msgstr "ubicaciÃ³n del archivo principal de configuraciÃ³n"
 
 #: common/config.cpp:1385
 msgid "location of language data files"
-msgstr "ubicación de los archivos de datos de idiomas"
+msgstr "ubicaciÃ³n de los archivos de datos de idiomas"
 
 #: common/config.cpp:1387
 msgid "create dictionary aliases"
@@ -106,15 +106,15 @@ msgstr "crear alias de diccionarios"
 
 #: common/config.cpp:1389
 msgid "location of the main word list"
-msgstr "ubicación del vocabulario principal"
+msgstr "ubicaciÃ³n del vocabulario principal"
 
 #: common/config.cpp:1391
 msgid "encoding to expect data to be in"
-msgstr "la codificación espera que la entrada esté en"
+msgstr "la codificaciÃ³n espera que la entrada estÃ© en"
 
 #: common/config.cpp:1393
 msgid "add or removes a filter"
-msgstr "añade o quita un filtro"
+msgstr "aÃ±ade o quita un filtro"
 
 #: common/config.cpp:1395
 msgid "path(s) aspell looks for filters"
@@ -134,7 +134,7 @@ msgstr "archivos con palabras adicionales a aceptar"
 
 #: common/config.cpp:1405
 msgid "location for personal files"
-msgstr "ubicación de los archivos personales"
+msgstr "ubicaciÃ³n de los archivos personales"
 
 #: common/config.cpp:1407
 msgid "ignore words <= n chars"
@@ -147,23 +147,23 @@ msgstr "ignorar los acentos al comprobar las palabras -- ACTUALMENTE IGNORADOS"
 
 #: common/config.cpp:1412
 msgid "ignore case when checking words"
-msgstr "ignorar mayúsculas al comprobar las palabras"
+msgstr "ignorar mayÃºsculas al comprobar las palabras"
 
 #: common/config.cpp:1414
 msgid "ignore commands to store replacement pairs"
-msgstr "ignorar órdenes para guardar pares de reemplazo"
+msgstr "ignorar Ã³rdenes para guardar pares de reemplazo"
 
 #: common/config.cpp:1416 common/config.cpp:1483
 msgid "extra information for the word list"
-msgstr "información adicional para el vocabulario"
+msgstr "informaciÃ³n adicional para el vocabulario"
 
 #: common/config.cpp:1418
 msgid "keyboard definition to use for typo analysis"
-msgstr "definición del teclado para análisis de errores tipográficos"
+msgstr "definiciÃ³n del teclado para anÃ¡lisis de errores tipogrÃ¡ficos"
 
 #: common/config.cpp:1420
 msgid "language code"
-msgstr "código del idioma"
+msgstr "cÃ³digo del idioma"
 
 #: common/config.cpp:1422
 msgid "deprecated, use lang instead"
@@ -171,7 +171,7 @@ msgstr "obsoleto, use lang en su lugar"
 
 #: common/config.cpp:1424
 msgid "location of local language data files"
-msgstr "ubicación de los archivos de datos de idiomas"
+msgstr "ubicaciÃ³n de los archivos de datos de idiomas"
 
 #: common/config.cpp:1426
 msgid "base name of the main dictionary to use"
@@ -179,33 +179,33 @@ msgstr "nombre base del diccionario principal a usar"
 
 #: common/config.cpp:1430
 msgid "set module name"
-msgstr "establecer nombre del módulo"
+msgstr "establecer nombre del mÃ³dulo"
 
 #: common/config.cpp:1432
 msgid "search order for modules"
-msgstr "orden de búsqueda para los módulos"
+msgstr "orden de bÃºsqueda para los mÃ³dulos"
 
 #: common/config.cpp:1434
 msgid "enable Unicode normalization"
-msgstr "activar normalización Unicode"
+msgstr "activar normalizaciÃ³n Unicode"
 
 #: common/config.cpp:1436
 msgid "Unicode normalization required for current lang"
-msgstr "Se requiere normalización Unicode para este idioma"
+msgstr "Se requiere normalizaciÃ³n Unicode para este idioma"
 
 #. TRANSLATORS: the values after the ':' are literal
 #. values and should not be translated.
 #: common/config.cpp:1440
 msgid "Unicode normalization form: none, nfd, nfc, comp"
-msgstr "Forma de normalización Unicode: none, nfd, nfc, comp"
+msgstr "Forma de normalizaciÃ³n Unicode: none, nfd, nfc, comp"
 
 #: common/config.cpp:1442
 msgid "avoid lossy conversions when normalization"
-msgstr "evitar conversiones con pérdidas en la normalización"
+msgstr "evitar conversiones con pÃ©rdidas en la normalizaciÃ³n"
 
 #: common/config.cpp:1444
 msgid "personal configuration file"
-msgstr "archivo de configuración personal"
+msgstr "archivo de configuraciÃ³n personal"
 
 #: common/config.cpp:1447
 msgid "personal dictionary file name"
@@ -225,11 +225,11 @@ msgstr "considerar legales las palabras aglutinadas"
 
 #: common/config.cpp:1457
 msgid "maximum number that can be strung together"
-msgstr "número máximo que pueden ser aglutinadas"
+msgstr "nÃºmero mÃ¡ximo que pueden ser aglutinadas"
 
 #: common/config.cpp:1459
 msgid "minimal length of interior words"
-msgstr "tamaño mínimo de las palabras interiores"
+msgstr "tamaÃ±o mÃ­nimo de las palabras interiores"
 
 #: common/config.cpp:1461
 msgid "consider camel case words legal"
@@ -239,18 +239,17 @@ msgstr "considerar legales las palabras en tipo Camello"
 msgid "save replacement pairs on save all"
 msgstr "guardar sustituciones con la orden \"save all\""
 
-# FUZZY
 #: common/config.cpp:1465
 msgid "set the prefix based on executable location"
-msgstr "fijar el prefijo según localización del ejecutable"
+msgstr "establecer el prefijo segÃºn la ubicaciÃ³n del ejecutable"
 
 #: common/config.cpp:1467
 msgid "size of the word list"
-msgstr "tamaño del vocabulario"
+msgstr "tamaÃ±o del vocabulario"
 
 #: common/config.cpp:1469
 msgid "no longer used"
-msgstr "no se usa más"
+msgstr "no se usa mÃ¡s"
 
 #: common/config.cpp:1471
 msgid "suggestion mode"
@@ -260,11 +259,11 @@ msgstr "modo de sugerencia"
 #. translated.
 #: common/config.cpp:1475
 msgid "use typo analysis, override sug-mode default"
-msgstr "usar análisis tipográfico, anula sug-mode predeterminado"
+msgstr "usar anÃ¡lisis tipogrÃ¡fico, anula sug-mode predeterminado"
 
 #: common/config.cpp:1477
 msgid "use replacement tables, override sug-mode default"
-msgstr "usar tablas de sustitución, anula sug-mode predeterminado"
+msgstr "usar tablas de sustituciÃ³n, anula sug-mode predeterminado"
 
 #: common/config.cpp:1479
 msgid "characters to insert when a word is split"
@@ -272,11 +271,11 @@ msgstr "caracteres a insertar cuando se divide una palabra"
 
 #: common/config.cpp:1481
 msgid "use personal, replacement & session dictionaries"
-msgstr "usar diccionarios personal, de reemplazo y de sesión"
+msgstr "usar diccionarios personal, de reemplazo y de sesiÃ³n"
 
 #: common/config.cpp:1485
 msgid "search path for word list information files"
-msgstr "ruta de búsqueda para archivos de información de vocabulario"
+msgstr "ruta de bÃºsqueda para archivos de informaciÃ³n de vocabulario"
 
 #: common/config.cpp:1487
 msgid "enable warnings"
@@ -289,51 +288,51 @@ msgstr "indicador para banderas de afijos en vocabularios -- ACTUALMENTE IGNORAD
 
 #: common/config.cpp:1499
 msgid "use affix compression when creating dictionaries"
-msgstr "usar compresión de afijos al crear diccionarios"
+msgstr "usar compresiÃ³n de afijos al crear diccionarios"
 
 #: common/config.cpp:1501
 msgid "remove invalid affix flags"
-msgstr "eliminar banderas de afijos inválidas"
+msgstr "eliminar banderas de afijos invÃ¡lidas"
 
 #: common/config.cpp:1503
 msgid "attempts to clean words so that they are valid"
-msgstr "intenta limpiar palabras para que sean válidas"
+msgstr "intenta limpiar palabras para que sean vÃ¡lidas"
 
 #: common/config.cpp:1505
 msgid "compute soundslike on demand rather than storing"
-msgstr "calcular semejanza a petición en lugar de guardar"
+msgstr "calcular semejanza a peticiÃ³n en lugar de guardar"
 
 #: common/config.cpp:1507
 msgid "partially expand affixes for better suggestions"
-msgstr "expansión parcial de afijos para mejores sugerencias"
+msgstr "expansiÃ³n parcial de afijos para mejores sugerencias"
 
 #: common/config.cpp:1509
 msgid "skip invalid words"
-msgstr "omitir palabras inválidas"
+msgstr "omitir palabras invÃ¡lidas"
 
 #: common/config.cpp:1511
 msgid "check if affix flags are valid"
-msgstr "comprobar si las banderas de afijos son válidas"
+msgstr "comprobar si las banderas de afijos son vÃ¡lidas"
 
 #: common/config.cpp:1513
 msgid "check if words are valid"
-msgstr "comprobar si las palabras son válidas"
+msgstr "comprobar si las palabras son vÃ¡lidas"
 
 #: common/config.cpp:1520
 msgid "create a backup file by appending \".bak\""
-msgstr "crear un archivo de respaldo añadiendo \".bak\""
+msgstr "crear un archivo de respaldo aÃ±adiendo \".bak\""
 
 #: common/config.cpp:1522
 msgid "use byte offsets instead of character offsets"
-msgstr "usar desplazamientos de byte en vez de desplazamientos de carácter"
+msgstr "usar desplazamientos de byte en vez de desplazamientos de carÃ¡cter"
 
 #: common/config.cpp:1524
 msgid "create missing root/affix combinations"
-msgstr "crear combinaciones faltantes de raíz/afijo"
+msgstr "crear combinaciones faltantes de raÃ­z/afijo"
 
 #: common/config.cpp:1526
 msgid "keymapping for check mode: \"aspell\" or \"ispell\""
-msgstr "mapa de teclas en modo de comprobación: \"aspell\" o \"ispell\""
+msgstr "mapa de teclas en modo de comprobaciÃ³n: \"aspell\" o \"ispell\""
 
 #: common/config.cpp:1528
 msgid "reverse the order of the suggest list"
@@ -345,30 +344,30 @@ msgstr "sugerir posibles sustituciones"
 
 #: common/config.cpp:1532
 msgid "time load time and suggest time in pipe mode"
-msgstr "tomar tiempo de carga y de sugerencia en modo tubería"
+msgstr "tomar tiempo de carga y de sugerencia en modo tuberÃ­a"
 
 #: common/convert.cpp:303 common/convert.cpp:497
 #, c-format
 msgid "This could also mean that the file \"%s\" could not be opened for reading or does not exist."
-msgstr "Esto también podría significar que el archivo \"%s\" no pudo abrirse para lectura, o no existe."
+msgstr "Esto tambiÃ©n podrÃ­a significar que el archivo \"%s\" no pudo abrirse para lectura, o no existe."
 
 #: common/convert.cpp:590 common/convert.cpp:702 common/convert.cpp:748
 #, c-format
 msgid "The Unicode code point U+%04X is unsupported."
-msgstr "El código Unicode U+%04X no está permitido."
+msgstr "El cÃ³digo Unicode U+%04X no estÃ¡ permitido."
 
 #: common/convert.cpp:887
 #, c-format
 msgid "Invalid UTF-8 sequence at position %ld."
-msgstr "Secuencia UTF-8 incorrecta en la posición %ld."
+msgstr "Secuencia UTF-8 incorrecta en la posiciÃ³n %ld."
 
 #: common/errors.cpp:27
 msgid "Operation Not Supported: %what:1"
-msgstr "Operación no permitida: %what:1"
+msgstr "OperaciÃ³n no permitida: %what:1"
 
 #: common/errors.cpp:43
 msgid "The method \"%what:1\" is unimplemented in \"%where:2\"."
-msgstr "El método \"%what:1\" no está implementado en \"%where:2\"."
+msgstr "El mÃ©todo \"%what:1\" no estÃ¡ implementado en \"%where:2\"."
 
 #: common/errors.cpp:51
 #, c-format
@@ -393,12 +392,12 @@ msgstr "No se puede abrir el archivo \"%file:1\" para escritura."
 #: common/errors.cpp:83
 #, c-format
 msgid "The file name \"%file:1\" is invalid."
-msgstr "El nombre de archivo \"%file:1\" no es válido."
+msgstr "El nombre de archivo \"%file:1\" no es vÃ¡lido."
 
 #: common/errors.cpp:91
 #, c-format
 msgid "The file \"%file:1\" is not in the proper format."
-msgstr "El archivo \"%file:1\" está en un formato incorrecto."
+msgstr "El archivo \"%file:1\" estÃ¡ en un formato incorrecto."
 
 #: common/errors.cpp:107
 #, c-format
@@ -411,17 +410,17 @@ msgstr "Clave \"%key:1\" desconocida."
 
 #: common/errors.cpp:131
 msgid "The value for option \"%key:1\" can not be changed."
-msgstr "No se puede cambiar el valor de la opción \"%key:1\"."
+msgstr "No se puede cambiar el valor de la opciÃ³n \"%key:1\"."
 
 # MAL!
 #: common/errors.cpp:139
 msgid "The key \"%key:1\" is not %accepted:2 and is thus invalid."
-msgstr "La clave \"%key:1\" no está %accepted:2 y por lo tanto es inválida."
+msgstr "La clave \"%key:1\" no estÃ¡ %accepted:2 y por lo tanto es invÃ¡lida."
 
 # MAL!
 #: common/errors.cpp:147
 msgid "The value \"%value:2\" is not %accepted:3 and is thus invalid for the key \"%key:1\"."
-msgstr "El valor \"%valor:2\" no está %accepted:3 y por lo tanto es inválido para la clave \"%key:1\"."
+msgstr "El valor \"%valor:2\" no estÃ¡ %accepted:3 y por lo tanto es invÃ¡lido para la clave \"%key:1\"."
 
 #: common/errors.cpp:163
 msgid "The key \"%key:1\" is not a string."
@@ -441,96 +440,92 @@ msgstr "La clave \"%key:1\" no es una lista."
 
 #: common/errors.cpp:195
 msgid "The key \"%key:1\" does not take any parameters when prefixed by a \"reset-\"."
-msgstr "La clave \"%key:1\" no admite parámetros cuando lleva el prefijo \"reset-\"."
+msgstr "La clave \"%key:1\" no admite parÃ¡metros cuando lleva el prefijo \"reset-\"."
 
 #: common/errors.cpp:203
 msgid "The key \"%key:1\" does not take any parameters when prefixed by an \"enable-\"."
-msgstr "La clave \"%key:1\" no admite parámetros cuando lleva el prefijo \"enable-\"."
+msgstr "La clave \"%key:1\" no admite parÃ¡metros cuando lleva el prefijo \"enable-\"."
 
 #: common/errors.cpp:211
 msgid "The key \"%key:1\" does not take any parameters when prefixed by a \"dont-\" or \"disable-\"."
 msgstr ""
-"La clave \"%key:1\" no admite parámetros cuando lleva el prefijo \"dont-\" o \n"
+"La clave \"%key:1\" no admite parÃ¡metros cuando lleva el prefijo \"dont-\" o \n"
 "\"disable-\"."
 
 #: common/errors.cpp:219
 msgid "The key \"%key:1\" does not take any parameters when prefixed by a \"clear-\"."
-msgstr "La clave \"%key:1\" no admite parámetros cuando lleva el prefijo \"clear-\"."
+msgstr "La clave \"%key:1\" no admite parÃ¡metros cuando lleva el prefijo \"clear-\"."
 
 #: common/errors.cpp:235
-#, c-format
 msgid "The language \"%lang:1\" is not known."
 msgstr "El idioma \"%lang:1\" no es conocido."
 
 #: common/errors.cpp:243
 #, c-format
 msgid "The soundslike \"%sl:2\" is not known."
-msgstr "El código \"soundslike\" \"%sl:2\" no es conocido."
+msgstr "El cÃ³digo \"soundslike\" \"%sl:2\" no es conocido."
 
 #: common/errors.cpp:251
-#, c-format
 msgid "The language \"%lang:1\" is not supported."
 msgstr "Idioma \"%lang:1\" no permitido."
 
 #: common/errors.cpp:259
-#, c-format
 msgid "No word lists can be found for the language \"%lang:1\"."
 msgstr "No se encontraron vocabularios para el idioma \"%lang:1\"."
 
 #: common/errors.cpp:267
-#, c-format
 msgid "Expected language \"%lang:1\" but got \"%prev:2\"."
 msgstr "Se esperaba \"%lang:1\", pero se ha encontrado \"%prev:2\"."
 
 #: common/errors.cpp:283
 #, c-format
 msgid "Affix '%aff:1' is corrupt."
-msgstr "El afijo \"%aff:1\" está corrupto."
+msgstr "El afijo \"%aff:1\" estÃ¡ corrupto."
 
 #: common/errors.cpp:291
 #, c-format
 msgid "The condition \"%cond:1\" is invalid."
-msgstr "La condición \"%cond:1\" es inválida."
+msgstr "La condiciÃ³n \"%cond:1\" es invÃ¡lida."
 
 #: common/errors.cpp:299
 #, c-format
 msgid "The condition \"%cond:1\" does not guarantee that \"%strip:2\" can always be stripped."
-msgstr "La condición \"%cond:1\" no garantiza que \"%strip:2\" se pueda eliminar siempre."
+msgstr "La condiciÃ³n \"%cond:1\" no garantiza que \"%strip:2\" se pueda eliminar siempre."
 
 #: common/errors.cpp:307
 #, c-format
 msgid "The file \"%file:1\" is not in the proper format. Expected the file to be in \"%exp:2\" not \"%got:3\"."
 msgstr ""
-"El archivo \"%file:1\" no está en el formato adecuado. Se esperaba que \n"
+"El archivo \"%file:1\" no estÃ¡ en el formato adecuado. Se esperaba que \n"
 "estuviera en \"%exp:2\" en lugar de en \"%got:3\""
 
 #: common/errors.cpp:323
 #, c-format
 msgid "The encoding \"%encod:1\" is not known."
-msgstr "Codificación \"%encod:1\" desconocida."
+msgstr "CodificaciÃ³n \"%encod:1\" desconocida."
 
 #: common/errors.cpp:331
 #, c-format
 msgid "The encoding \"%encod:1\" is not supported."
-msgstr "Codificación \"%encod:1\" no permitida."
+msgstr "CodificaciÃ³n \"%encod:1\" no permitida."
 
 #: common/errors.cpp:339
 #, c-format
 msgid "The conversion from \"%encod:1\" to \"%encod2:2\" is not supported."
-msgstr "La conversión de \"%encod:1\" a \"%encod2:2\" no está permitida."
+msgstr "La conversiÃ³n de \"%encod:1\" a \"%encod2:2\" no estÃ¡ permitida."
 
 #: common/errors.cpp:379
 #, c-format
 msgid "The string \"%str:1\" is invalid."
-msgstr "La cadena \"%str:1\" no es válida."
+msgstr "La cadena \"%str:1\" no es vÃ¡lida."
 
 #: common/errors.cpp:387
 msgid "The word \"%word:1\" is invalid."
-msgstr "La palabra \"%word:1\" no es válida."
+msgstr "La palabra \"%word:1\" no es vÃ¡lida."
 
 #: common/errors.cpp:395
 msgid "The affix flag '%aff:1' is invalid for word \"%word:2\"."
-msgstr "La bandera de afijo '%aff:1' no es válida para la palabra \"%word:2\"."
+msgstr "La bandera de afijo '%aff:1' no es vÃ¡lida para la palabra \"%word:2\"."
 
 #: common/errors.cpp:403
 msgid "The affix flag '%aff:1' can not be applied to word \"%word:2\"."
@@ -538,16 +533,16 @@ msgstr "La bandera de afijo '%aff:1' no puede aplicarse a la palabra \"%word:2\"
 
 #: common/errors.cpp:451
 msgid "not a version number"
-msgstr "no es un número de versión"
+msgstr "no es un nÃºmero de versiÃ³n"
 
 #: common/errors.cpp:467
 msgid "dlopen returned \"%return:1\"."
-msgstr "dlopen devolvió \"%return:1\"."
+msgstr "dlopen devolviÃ³ \"%return:1\"."
 
 #: common/errors.cpp:475
 #, c-format
 msgid "The file \"%filter:1\" does not contain any filters."
-msgstr "El archivo \"%file:1\" no contiene ningún filtro."
+msgstr "El archivo \"%file:1\" no contiene ningÃºn filtro."
 
 #: common/errors.cpp:483
 #, c-format
@@ -560,36 +555,36 @@ msgstr "Confundido por el control de versiones."
 
 #: common/errors.cpp:499
 msgid "Aspell version does not match filter's requirement."
-msgstr "La versión de Aspell no coincide con la requerida por el filtro."
+msgstr "La versiÃ³n de Aspell no coincide con la requerida por el filtro."
 
 #: common/errors.cpp:507
 msgid "Filter option already exists."
-msgstr "La opción de filtrado ya existe."
+msgstr "La opciÃ³n de filtrado ya existe."
 
 #: common/errors.cpp:515
 msgid "Use option modifiers only within named option."
-msgstr "Usar modificadores de opción sólo dentro de opciones con nombre."
+msgstr "Usar modificadores de opciÃ³n sÃ³lo dentro de opciones con nombre."
 
 #: common/errors.cpp:523
 msgid "Option modifier unknown."
-msgstr "Modificador de opción desconocido."
+msgstr "Modificador de opciÃ³n desconocido."
 
 #: common/errors.cpp:531
 msgid "Error setting filter description."
-msgstr "Error asignando descripción del filtro."
+msgstr "Error asignando descripciÃ³n del filtro."
 
 #: common/errors.cpp:547
 msgid "Empty option specifier."
-msgstr "Especificador de opción vacío."
+msgstr "Especificador de opciÃ³n vacÃ­o."
 
 #: common/errors.cpp:555
 #, c-format
 msgid "Option \"%option:1\" possibly specified prior to filter."
-msgstr "La opción \"%option:1\" posiblemente se especificó antes que el filtro."
+msgstr "La opciÃ³n \"%option:1\" posiblemente se especificÃ³ antes que el filtro."
 
 #: common/errors.cpp:563
 msgid "Unknown mode description key \"%key:1\"."
-msgstr "Clave \"%key:1\" de descripción de modo desconocida."
+msgstr "Clave \"%key:1\" de descripciÃ³n de modo desconocida."
 
 #: common/errors.cpp:571
 #, c-format
@@ -598,20 +593,20 @@ msgstr "Esperando la tecla \"%modekey:1\"."
 
 #: common/errors.cpp:579
 msgid "Version specifier missing key: \"aspell\"."
-msgstr "El especificador de versión no contiene la clave: \"aspell\"."
+msgstr "El especificador de versiÃ³n no contiene la clave: \"aspell\"."
 
 #: common/errors.cpp:595
 msgid "Aspell version does not match mode's requirement."
-msgstr "La versión de Aspell no coincide con el requerimiento del modo."
+msgstr "La versiÃ³n de Aspell no coincide con el requerimiento del modo."
 
 #: common/errors.cpp:603
 msgid "Missing magic mode expression."
-msgstr "Falta expresión de modo mágico."
+msgstr "Falta expresiÃ³n de modo mÃ¡gico."
 
 #: common/errors.cpp:611
 #, c-format
 msgid "Empty extension at char %char:1."
-msgstr "Extensión vacía en el carácter %char:1."
+msgstr "ExtensiÃ³n vacÃ­a en el carÃ¡cter %char:1."
 
 #: common/errors.cpp:619
 #, c-format
@@ -626,33 +621,32 @@ msgstr "Modo desconocido: \"%mode:1\"."
 #: common/errors.cpp:635
 #, c-format
 msgid "\"%mode:1\" error while extend Aspell modes. (out of memory?)"
-msgstr "Error de \"%mode:1\" mientras se extendían los modos de Aspell. (¿Memoria agotada?)"
+msgstr "Error de \"%mode:1\" mientras se extendÃ­an los modos de Aspell. (Â¿Memoria agotada?)"
 
 #: common/errors.cpp:651
 #, c-format
 msgid "\"%mode:1\": no start for magic search given for magic \"%magic:2\"."
-msgstr "\"%mode:1\": no se dió comienzo para la búsqueda mágica de \"%magic:2\"."
+msgstr "\"%mode:1\": no se diÃ³ comienzo para la bÃºsqueda mÃ¡gica de \"%magic:2\"."
 
 #: common/errors.cpp:659
 #, c-format
 msgid "\"%mode:1\": no range for magic search given for magic \"%magic:2\"."
-msgstr "\"%mode:1\": no se dió rango para la búsqueda mágica de \"%magic:2\"."
+msgstr "\"%mode:1\": no se diÃ³ rango para la bÃºsqueda mÃ¡gica de \"%magic:2\"."
 
 #: common/errors.cpp:667
 #, c-format
 msgid "\"%mode:1\": no magic expression available for magic \"%magic:2\"."
-msgstr "\"%mode:1\": no hay ninguna expresión mágica disponible para \"%magic:2\"."
+msgstr "\"%mode:1\": no hay ninguna expresiÃ³n mÃ¡gica disponible para \"%magic:2\"."
 
 #: common/errors.cpp:675
 msgid "\"%mode:1\": Magic \"%magic:2\": bad regular expression after location specifier; regexp reports: \"%regerr:3\"."
-msgstr "\"%mode:1\": Magic \"%magic:2\":  expresión regular incorrecta después del parámetro de localización; regexp devolvió: \"%regerr:3\"."
+msgstr "\"%mode:1\": Magic \"%magic:2\":  expresiÃ³n regular incorrecta despuÃ©s del parÃ¡metro de localizaciÃ³n; regexp devolviÃ³: \"%regerr:3\"."
 
 #: common/errors.cpp:691
 #, c-format
 msgid "\"%expression:1\" is not a valid regular expression."
-msgstr "\"%expression:1\" no es una expresión regular válida."
+msgstr "\"%expression:1\" no es una expresiÃ³n regular vÃ¡lida."
 
-# FUZZY
 #: common/posib_err.cpp:114
 msgid "Unhandled Error: "
 msgstr "Error no manejado: "
@@ -689,34 +683,35 @@ msgstr "entrar en modo Markdown."
 #: prog/aspell.cpp:315
 #, c-format
 msgid "Invalid Option: %s"
-msgstr "Opción inválida: %s"
+msgstr "OpciÃ³n invÃ¡lida: %s"
 
 #: prog/aspell.cpp:322
-msgid " does not take any parameters."
-msgstr " no admite ningún parámetro."
+#, c-format
+msgid "'%s' does not take any parameters."
+msgstr "'%s' no admite ningÃºn parÃ¡metro."
 
 #: prog/aspell.cpp:335 prog/aspell.cpp:395
 #, c-format
 msgid "You must specify a parameter for \"%s\"."
-msgstr "Debe especificar un parámetro para \"%s\"."
+msgstr "Debe especificar un parÃ¡metro para \"%s\"."
 
 #: prog/aspell.cpp:384
 msgid "You must specify an action"
-msgstr "Debe especificar una acción"
+msgstr "Debe especificar una acciÃ³n"
 
 #: prog/aspell.cpp:392 prog/aspell.cpp:455 prog/aspell.cpp:477
 #, c-format
 msgid "Unknown Action: %s"
-msgstr "Acción desconocida: %s"
+msgstr "AcciÃ³n desconocida: %s"
 
 #: prog/aspell.cpp:398
 #, c-format
 msgid "Error: You must specify at least %d parameters for \"%s\".\n"
-msgstr "Error: Debe especificar al menos %d parámetros para \"%s\".\n"
+msgstr "Error: Debe especificar al menos %d parÃ¡metros para \"%s\".\n"
 
 #: prog/aspell.cpp:640
 msgid "Invalid Input"
-msgstr "Entrada inválida"
+msgstr "Entrada invÃ¡lida"
 
 #: prog/aspell.cpp:713
 #, c-format
@@ -738,7 +733,7 @@ msgstr "Debe especificar un nombre de archivo."
 
 #: prog/aspell.cpp:980
 msgid "Only one file name may be specified."
-msgstr "Sólo se puede especificar un nombre de archivo."
+msgstr "SÃ³lo se puede especificar un nombre de archivo."
 
 #: prog/aspell.cpp:990
 #, c-format
@@ -748,7 +743,7 @@ msgstr "No se puede abrir \"%s\" para lectura"
 #: prog/aspell.cpp:1003
 #, c-format
 msgid "Invalid keymapping: %s"
-msgstr "Mapa de teclado inválido: %s"
+msgstr "Mapa de teclado invÃ¡lido: %s"
 
 #: prog/aspell.cpp:1018
 #, c-format
@@ -758,7 +753,7 @@ msgstr "\"%s\" no es un archivo regular"
 #: prog/aspell.cpp:1029
 #, c-format
 msgid "Could not open the file \"%s\" for writing. File not saved."
-msgstr "No se pudo abrir \"%s\" para escritura. El archivo no se guardó."
+msgstr "No se pudo abrir \"%s\" para escritura. El archivo no se guardÃ³."
 
 #: prog/aspell.cpp:1042
 msgid "Ignore"
@@ -778,11 +773,11 @@ msgstr "Sustituir todos"
 
 #: prog/aspell.cpp:1046
 msgid "Add"
-msgstr "Añadir"
+msgstr "AÃ±adir"
 
 #: prog/aspell.cpp:1047
 msgid "Add Lower"
-msgstr "Añadir minúsculas"
+msgstr "AÃ±adir minÃºsculas"
 
 #: prog/aspell.cpp:1048
 msgid "Abort"
@@ -792,10 +787,9 @@ msgstr "Cancelar"
 msgid "Exit"
 msgstr "Salir"
 
-# FUZZY
 #: prog/aspell.cpp:1125
 msgid "Are you sure you want to abort (y/n)? "
-msgstr "¿Está seguro de que quiere cancelar (s/n)? "
+msgstr "Â¿EstÃ¡ seguro de que quiere cancelar (s/n)? "
 
 #. TRANSLATORS: The user may input any of these characters to say "yes".
 #. MUST ONLY CONSIST OF ASCII CHARACTERS.
@@ -810,15 +804,15 @@ msgstr "Con: "
 
 #: prog/aspell.cpp:1174
 msgid "Sorry that is an invalid choice!"
-msgstr "Disculpe, ¡la selección no es válida!"
+msgstr "Disculpe, Â¡la selecciÃ³n no es vÃ¡lida!"
 
 #: prog/aspell.cpp:1545
 msgid "Can't merge a master word list yet. Sorry."
-msgstr "Disculpe. Todavía no se puede mezclar un vocabulario principal."
+msgstr "Disculpe. TodavÃ­a no se puede mezclar un vocabulario principal."
 
 #: prog/aspell.cpp:1569
 msgid "Sorry \"create/merge personal\" is currently unimplemented.\n"
-msgstr "Disculpe \"create/merge personal\" está actualmente sin implementar.\n"
+msgstr "Disculpe \"create/merge personal\" estÃ¡ actualmente sin implementar.\n"
 
 #: prog/aspell.cpp:1578 prog/aspell.cpp:1634
 #, c-format
@@ -827,12 +821,12 @@ msgstr "Disculpe, no voy a sobreescribir \"%s\""
 
 #: prog/aspell.cpp:1625
 msgid "Sorry \"create/merge repl\" is currently unimplemented.\n"
-msgstr "Disculpe \"create/merge repl\" está actualmente sin implementar.\n"
+msgstr "Disculpe \"create/merge repl\" estÃ¡ actualmente sin implementar.\n"
 
 #: prog/aspell.cpp:1897
 #, c-format
 msgid "\"%s\" is not a valid flag for the \"munch-list\" command."
-msgstr "\"%s\" no es una bandera válida para la orden \"munch-list\"."
+msgstr "\"%s\" no es una bandera vÃ¡lida para la orden \"munch-list\"."
 
 #. TRANSLATORS: These should all be formated to fit in 80 column or
 #. less
@@ -854,7 +848,7 @@ msgstr "  help                muestra un mensaje detallado de ayuda"
 
 #: prog/aspell.cpp:2833
 msgid "  -c|check <file>  spellchecks a file"
-msgstr "  -c|check <archivo>  para comprobar la ortografía de un archivo"
+msgstr "  -c|check <archivo>  para comprobar la ortografÃ­a de un archivo"
 
 #: prog/aspell.cpp:2834
 msgid "  -a|pipe          \"ispell -a\" compatibility mode"
@@ -862,11 +856,11 @@ msgstr "  -a|pipe             modo de compatibilidad con \"ispell -a\""
 
 #: prog/aspell.cpp:2835
 msgid "  [dump] config    dumps the current configuration to stdout"
-msgstr "  [dump] config       vuelca la configuración actual a la salida estándar"
+msgstr "  [dump] config       vuelca la configuraciÃ³n actual a la salida estÃ¡ndar"
 
 #: prog/aspell.cpp:2836
 msgid "  config <key>     prints the current value of an option"
-msgstr "  congif <key>        imprime el valor actual de una opción"
+msgstr "  config <key>        imprime el valor actual de una opciÃ³n"
 
 #: prog/aspell.cpp:2837
 msgid "  [dump] dicts | filters | modes"
@@ -874,7 +868,7 @@ msgstr "  [dump] dicts | filters | modes"
 
 #: prog/aspell.cpp:2838
 msgid "    lists available dictionaries / filters / filter modes"
-msgstr "    enlista los diccionarios / filtros / modos de filtrado disponibles"
+msgstr "    lista los diccionarios / filtros / modos de filtrado disponibles"
 
 #: prog/aspell.cpp:2839
 msgid "[options] is any of the following:"
@@ -884,15 +878,15 @@ msgstr "[opciones] es cualquiera de las siguientes:"
 msgid "  list             produce a list of misspelled words from standard input"
 msgstr ""
 "  list            produce una lista de palabras incorrectas desde la entrada\n"
-"                  estándar"
+"                  estÃ¡ndar"
 
 #: prog/aspell.cpp:2855
 msgid "  soundslike       returns the sounds like equivalent for each word entered"
-msgstr "  soundslike      devuelve el equivalente fonético de cada palabra introducida"
+msgstr "  soundslike      devuelve el equivalente fonÃ©tico de cada palabra introducida"
 
 #: prog/aspell.cpp:2856
 msgid "  munch            generate possible root words and affixes"
-msgstr "  munch           genera posibles raíces y afijos de palabras"
+msgstr "  munch           genera posibles raÃ­ces y afijos de palabras"
 
 #: prog/aspell.cpp:2857
 msgid "  expand [1-4]     expands affix flags"
@@ -901,8 +895,8 @@ msgstr "  expand [1-4]    expande las banderas no fijas"
 #: prog/aspell.cpp:2858
 msgid "  clean [strict]   cleans a word list so that every line is a valid word"
 msgstr ""
-"  clean [strict]  limpia un vocabulario de forma que cada línea sea una\n"
-"                  palabra válida"
+"  clean [strict]  limpia un vocabulario de forma que cada lÃ­nea sea una\n"
+"                  palabra vÃ¡lida"
 
 #: prog/aspell.cpp:2859
 msgid "  filter           filters input as if it was being spellchecked"
@@ -910,7 +904,7 @@ msgstr "  filter          filtra la entrada como si estuviera siendo comprobada"
 
 #: prog/aspell.cpp:2860
 msgid "  -v|version       prints a version line"
-msgstr "  -v|version      imprime una línea de versión"
+msgstr "  -v|version      imprime una lÃ­nea de versiÃ³n"
 
 #: prog/aspell.cpp:2861
 msgid "  munch-list [simple] [single|multi] [keep]"
@@ -918,7 +912,7 @@ msgstr "  munch-list [simple] [single|multi] [keep]"
 
 #: prog/aspell.cpp:2862
 msgid "    reduce the size of a word list via affix compression"
-msgstr "    reduce el tamaño de un vocabulario via compresión de afijos."
+msgstr "    reduce el tamaÃ±o de un vocabulario vÃ­a compresiÃ³n de afijos."
 
 #: prog/aspell.cpp:2863
 msgid "  conv <from> <to> [<norm-form>]"
@@ -926,15 +920,15 @@ msgstr "  conv <origen> <destino> [<forma-norm>]"
 
 #: prog/aspell.cpp:2864
 msgid "    converts from one encoding to another"
-msgstr "    convierte de un código a otro"
+msgstr "    convierte de un cÃ³digo a otro"
 
 #: prog/aspell.cpp:2865
 msgid "  norm (<norm-map> | <from> <norm-map> <to>) [<norm-form>]"
-msgstr "  norm (<mapa de normalización> | <origen> <mapa-norm> <destino>) [<forma-norm>]"
+msgstr "  norm (<mapa de normalizaciÃ³n> | <origen> <mapa-norm> <destino>) [<forma-norm>]"
 
 #: prog/aspell.cpp:2866
 msgid "    perform Unicode normalization"
-msgstr "    realizar normalización Unicode"
+msgstr "    realizar normalizaciÃ³n Unicode"
 
 #: prog/aspell.cpp:2869
 msgid "  dump|create|merge master|personal|repl [<name>]"
@@ -948,17 +942,17 @@ msgstr "    vuelca, crea o mezcla un diccionario maestro, personal o de reemplaz
 #. and should not be translated.
 #: prog/aspell.cpp:2874
 msgid "  <norm-form>      normalization form to use, either none, internal, or strict"
-msgstr "  <forma-norm>    forma de normalización a usar, ya sea none, internal o strict"
+msgstr "  <forma-norm>    forma de normalizaciÃ³n a usar, ya sea none, internal o strict"
 
 #: prog/aspell.cpp:2884
 #, c-format
 msgid ""
 "\n"
-"Aspell %s.  Copyright 2000-2019 by Kevin Atkinson.\n"
+"Aspell %s.  Copyright 2000-2023 by Kevin Atkinson.\n"
 "\n"
 msgstr ""
 "\n"
-"Aspell %s. Copyright 2000-2019 por Kevin Atkinson.\n"
+"Aspell %s. Copyright 2000-2025 por Kevin Atkinson.\n"
 "\n"
 
 #: prog/aspell.cpp:2918
@@ -970,7 +964,7 @@ msgid ""
 msgstr ""
 "Diccionarios disponibles:\n"
 "    Los diccionarios pueden seleccionarse mediante las opciones \"-d\"\n"
-"    o \"master\". También pueden seleccionarse indirectamente mediante\n"
+"    o \"master\". TambiÃ©n pueden seleccionarse indirectamente mediante\n"
 "    las opciones \"lang\", \"variety\" y \"size\".\n"
 
 #: prog/aspell.cpp:2939
@@ -979,7 +973,7 @@ msgid ""
 "    Filters can be added or removed via the \"filter\" option.\n"
 msgstr ""
 "Filtros disponibles (y opciones asociadas):\n"
-"    Los filtros pueden añadirse o quitarse a través de la opción \"filter\".\n"
+"    Los filtros pueden aÃ±adirse o quitarse a travÃ©s de la opciÃ³n \"filter\".\n"
 
 #: prog/aspell.cpp:2946
 #, c-format
@@ -1001,9 +995,9 @@ msgid ""
 msgstr ""
 "Modos de filtro disponibles:\n"
 "    Los modos de filtro son combinaciones reconfiguradas de filtros optimiza-\n"
-"    dos para archivos de un tipo específico.  Los modos se seleccionan a tra-\n"
-"    vés de la opción \"mode\". Esto sucederá implícitamente si Aspell es capaz\n"
-"    de identificar el tipo de archivo por su extensión y posiblemente por los\n"
+"    dos para archivos de un tipo especÃ­fico.  Los modos se seleccionan a tra-\n"
+"    vÃ©s de la opciÃ³n \"mode\". Esto sucederÃ¡ implÃ­citamente si Aspell es capaz\n"
+"    de identificar el tipo de archivo por su extensiÃ³n y posiblemente por los\n"
 "    contenidos del archivo.\n"
 
 #: prog/check_funs.cpp:287
@@ -1031,7 +1025,7 @@ msgstr "Control-H"
 
 #: prog/check_funs.cpp:782
 msgid "Delete the previous character"
-msgstr "Borrar el carácter anterior"
+msgstr "Borrar el carÃ¡cter anterior"
 
 #. TRANSLATORS: This is a literal Key.
 #: prog/check_funs.cpp:785
@@ -1073,7 +1067,7 @@ msgstr "Control-A"
 
 #: prog/check_funs.cpp:800
 msgid "Move to the beginning of the line"
-msgstr "Moverse al comienzo de la línea"
+msgstr "Moverse al comienzo de la lÃ­nea"
 
 #. TRANSLATORS: This is a literal Key.
 #: prog/check_funs.cpp:803
@@ -1087,7 +1081,7 @@ msgstr "Control-E"
 
 #: prog/check_funs.cpp:806
 msgid "Move to the end of the line"
-msgstr "Moverse al final de la línea"
+msgstr "Moverse al final de la lÃ­nea"
 
 #. TRANSLATORS: This is a literal Key.
 #: prog/check_funs.cpp:809
@@ -1101,7 +1095,7 @@ msgstr "Control-D"
 
 #: prog/check_funs.cpp:812
 msgid "Delete the next character"
-msgstr "Borrar el siguiente carácter"
+msgstr "Borrar el siguiente carÃ¡cter"
 
 #. TRANSLATORS: This is a literal Key.
 #: prog/check_funs.cpp:816
@@ -1110,7 +1104,7 @@ msgstr "Control-K"
 
 #: prog/check_funs.cpp:817
 msgid "Kill all characters to the EOL"
-msgstr "Borrar todos los caracteres hasta el final de línea"
+msgstr "Borrar todos los caracteres hasta el final de lÃ­nea"
 
 #. TRANSLATORS: This is a literal Key.
 #: prog/check_funs.cpp:821
@@ -1119,7 +1113,7 @@ msgstr "Control-C"
 
 #: prog/check_funs.cpp:822
 msgid "Abort This Operation"
-msgstr "Cancelar esta operación"
+msgstr "Cancelar esta operaciÃ³n"
 
 #: modules/speller/default/language.cpp:103
 msgid "This is probably because: "
@@ -1131,36 +1125,36 @@ msgstr "Falta el campo requerido \"nombre\"."
 
 #: modules/speller/default/language.cpp:524
 msgid "Empty string."
-msgstr "Cadena vacía."
+msgstr "Cadena vacÃ­a."
 
 #: modules/speller/default/language.cpp:533
 #, c-format
 msgid "The character '%s' (U+%02X) may not appear at the beginning of a word."
-msgstr "El carácter '%s' (U+%02X) no debe aparecer al principio de una palabra."
+msgstr "El carÃ¡cter '%s' (U+%02X) no debe aparecer al principio de una palabra."
 
 #: modules/speller/default/language.cpp:535
 #: modules/speller/default/language.cpp:544
 #, c-format
 msgid "The character '%s' (U+%02X) must be followed by an alphabetic character."
-msgstr "El carácter '%s' (U+%02X) debe tener a continuación un carácter alfabético."
+msgstr "El carÃ¡cter '%s' (U+%02X) debe tener a continuaciÃ³n un carÃ¡cter alfabÃ©tico."
 
 #: modules/speller/default/language.cpp:537
 msgid "Does not contain any alphabetic characters."
-msgstr "No contiene ningún carácter alfabético."
+msgstr "No contiene ningÃºn carÃ¡cter alfabÃ©tico."
 
 #: modules/speller/default/language.cpp:542
 #, c-format
 msgid "The character '%s' (U+%02X) may not appear in the middle of a word."
-msgstr "El carácter '%s' (U+%02X) no debe aparecer en medio de una palabra."
+msgstr "El carÃ¡cter '%s' (U+%02X) no debe aparecer en medio de una palabra."
 
 #: modules/speller/default/language.cpp:549
 msgid "The character '\\r' (U+0D) may not appear at the end of a word. This probably means means that the file is using MS-DOS EOL instead of Unix EOL."
-msgstr "El carácter '\\r' (U+0D) no debe aparecer al final de una palabra. Eso probablemente signifique que el archivo está usando el fin de línea de MS-DOS en lugar del de Unix."
+msgstr "El carÃ¡cter '\\r' (U+0D) no debe aparecer al final de una palabra. Eso probablemente signifique que el archivo estÃ¡ usando el fin de lÃ­nea de MS-DOS en lugar del de Unix."
 
 #: modules/speller/default/language.cpp:552
 #, c-format
 msgid "The character '%s' (U+%02X) may not appear at the end of a word."
-msgstr "El carácter '%s' (U+%02X) no debe aparecer al final de una palabra."
+msgstr "El carÃ¡cter '%s' (U+%02X) no debe aparecer al final de una palabra."
 
 #: modules/speller/default/language.cpp:584
 #, c-format
@@ -1192,7 +1186,7 @@ msgstr "Recuento posiblemente incorrecto."
 
 #: modules/speller/default/readonly_ws.cpp:362
 msgid "Incompatible hash function."
-msgstr "Función resumen (hash) incompatible."
+msgstr "FunciÃ³n resumen (hash) incompatible."
 
 #: modules/speller/default/readonly_ws.cpp:440
 msgid "Wrong endian order."
@@ -1200,11 +1194,11 @@ msgstr "Orden endian incorrecta."
 
 #: modules/speller/default/readonly_ws.cpp:463
 msgid "Wrong soundslike."
-msgstr "Pronunciación incorrecta."
+msgstr "PronunciaciÃ³n incorrecta."
 
 #: modules/speller/default/readonly_ws.cpp:469
 msgid "Wrong soundslike version."
-msgstr "Versión de pronunciación incorrecta."
+msgstr "VersiÃ³n de pronunciaciÃ³n incorrecta."
 
 #: modules/speller/default/readonly_ws.cpp:936
 msgid "Affix flags found in word but no affix file given."
@@ -1212,13 +1206,13 @@ msgstr "Se encontraron banderas de afijo en la palabra pero no se ha especificad
 
 #: modules/speller/default/readonly_ws.cpp:974
 msgid "The total word length, with soundslike data, is larger than 240 characters."
-msgstr "La longitud total de la palabra, con los datos de pronunciación, es mayor de 240 caracteres."
+msgstr "La longitud total de la palabra, con los datos de pronunciaciÃ³n, es mayor de 240 caracteres."
 
 #: modules/speller/default/multi_ws.cpp:58
 msgid "There must be at least one \"add\" line."
-msgstr "Debe haber al menos una línea \"add\"."
+msgstr "Debe haber al menos una lÃ­nea \"add\"."
 
-#: modules/speller/default/suggest.cpp:1720
+#: modules/speller/default/suggest.cpp:1730
 msgid "one of ultra, fast, normal, slow, or bad-spellers"
 msgstr "uno entre ultra, fast, normal, slow y bad-spellers"
 
@@ -1228,22 +1222,22 @@ msgstr "no es uno de los tipos permitidos"
 
 #: modules/speller/default/speller_impl.cpp:334
 msgid "The personal word list is unavailable."
-msgstr "El vocabulario personal no está disponible."
+msgstr "El vocabulario personal no estÃ¡ disponible."
 
 #: modules/speller/default/speller_impl.cpp:341
 msgid "The session word list is unavailable."
-msgstr "El vocabulario de la sesión no está disponible."
+msgstr "El vocabulario de la sesiÃ³n no estÃ¡ disponible."
 
 #: modules/speller/default/speller_impl.cpp:348
 msgid "The main word list is unavailable."
-msgstr "El vocabulario principal no está disponible."
+msgstr "El vocabulario principal no estÃ¡ disponible."
 
 #: modules/filter/tex.cpp:255 modules/filter/tex.cpp:262
 msgid "a string of 'o','O','p',or 'P'"
 msgstr "una cadena de 'o', 'O', 'p', o 'P'"
 
 #. TRANSLATORS: Like the strings in config.cpp, all strings in *-filter.opt
-#. should be under 50 characters, begin with a lower case character and 
+#. should be under 50 characters, begin with a lower case character and
 #. not include any trailing punctuation marks.
 #: modules/filter/context-filter.info:7
 msgid "experimental filter for hiding delimited contexts"
@@ -1259,7 +1253,7 @@ msgstr "cambia entre texto visible e invisible"
 
 #: modules/filter/email-filter.info:7
 msgid "filter for skipping quoted text in email messages"
-msgstr "filtro para omitir texto citado en correos electrónicos"
+msgstr "filtro para omitir texto citado en correos electrÃ³nicos"
 
 #: modules/filter/email-filter.info:13
 msgid "email quote characters"
@@ -1267,7 +1261,7 @@ msgstr "comillas de email"
 
 #: modules/filter/email-filter.info:21
 msgid "num chars that can appear before the quote char"
-msgstr "núm de caracteres admitidos antes de las comillas de email"
+msgstr "nÃºm de caracteres admitidos antes de las comillas de email"
 
 #: modules/filter/html-filter.info:9
 msgid "filter for dealing with HTML documents"
@@ -1291,23 +1285,31 @@ msgstr "omitir etiquetas de enlace en las definiciones de referencias de enlace"
 
 #: modules/filter/markdown-filter.info:20
 msgid "support tags that span multiple lines outside of HTML blocks"
-msgstr "Admitir etiquetas que abarquen varias líneas fuera de bloques HTML"
+msgstr "Admitir etiquetas que abarquen varias lÃ­neas fuera de bloques HTML"
 
 #: modules/filter/markdown-filter.info:26
 msgid "HTML tags that start an HTML block that allows blank lines"
-msgstr "etiquetas HTML que comienzan un bloque HTML que permite líneas vacías"
+msgstr "etiquetas HTML que comienzan un bloque HTML que permite lÃ­neas vacÃ­as"
 
 #: modules/filter/markdown-filter.info:34
 msgid "HTML tags that start an HTML block that ends with a blank line"
-msgstr "etiquetas HTML que comienzan un bloque HTML que termina en una línea vacía"
+msgstr "etiquetas HTML que comienzan un bloque HTML que termina en una lÃ­nea vacÃ­a"
 
 #: modules/filter/nroff-filter.info:7
 msgid "filter for dealing with Nroff documents"
 msgstr "filtro para trabajar con documentos Nroff"
 
+#: modules/filter/po-filter.info:7
+msgid "filter to deal with gettext .po files"
+msgstr "filtro para trabajar con ficheros .po de gettext"
+
+#: modules/filter/po-filter.info:13
+msgid "review only msgids"
+msgstr "revisar solamente msgids"
+
 #: modules/filter/sgml-filter.info:9
 msgid "filter for dealing with generic SGML/XML documents"
-msgstr "filtro para trabajar con documentos SGML/XML genéricos"
+msgstr "filtro para trabajar con documentos SGML/XML genÃ©ricos"
 
 #: modules/filter/sgml-filter.info:15
 msgid "SGML attributes to always check"
@@ -1327,7 +1329,7 @@ msgstr "comprobar dentro de comentarios TeX"
 
 #: modules/filter/tex-filter.info:21
 msgid "TeX commands"
-msgstr "órdenes TeX"
+msgstr "Ã³rdenes TeX"
 
 #: modules/filter/texinfo-filter.info:7
 msgid "filter for dealing with Texinfo documents"
@@ -1335,7 +1337,7 @@ msgstr "filtro para trabajar con documentos Texinfo"
 
 #: modules/filter/texinfo-filter.info:13
 msgid "Texinfo commands to ignore the parameters of"
-msgstr "ignorar los parámetros de estas órdenes Texinfo"
+msgstr "ignorar los parÃ¡metros de estas Ã³rdenes Texinfo"
 
 #: modules/filter/texinfo-filter.info:41
 msgid "Texinfo environments to ignore"
@@ -1351,11 +1353,11 @@ msgstr "modo para comprobar comentarios y literales de cadenas en C++"
 
 #: modules/filter/modes/comment.amf:5
 msgid "mode to check any lines starting with a #"
-msgstr "modo para comprobar líneas que comiencen por #"
+msgstr "modo para comprobar lÃ­neas que comiencen por #"
 
 #: modules/filter/modes/email.amf:5
 msgid "mode for skipping quoted text in email messages"
-msgstr "modo para omitir texto citado en correos electrónicos"
+msgstr "modo para omitir texto citado en correos electrÃ³nicos"
 
 #: modules/filter/modes/html.amf:10
 msgid "mode for checking HTML documents"
@@ -1377,9 +1379,13 @@ msgstr "modo para comprobar documentos Nroff"
 msgid "mode for checking Perl comments and string literals"
 msgstr "modo para comprobar comentarios y literales de cadenas en Perl"
 
+#: modules/filter/modes/po.amf:7
+msgid "mode for checking gettext .po files"
+msgstr "modo para comprobar ficheros Texinfo"
+
 #: modules/filter/modes/sgml.amf:8
 msgid "mode for checking generic SGML/XML documents"
-msgstr "modo para comprobar documentos SGML/XML genéricos"
+msgstr "modo para comprobar documentos SGML/XML genÃ©ricos"
 
 #: modules/filter/modes/tex.amf:7
 msgid "mode for checking TeX/LaTeX documents"
@@ -1394,22 +1400,20 @@ msgid "mode to skip URL like constructs (default mode)"
 msgstr "modo para saltarse construcciones tipo URL (modo predeterminado)"
 
 #~ msgid "edit distance to use, override sug-mode default"
-#~ msgstr "editar distancia de uso, anulación de sug-mode predeterminada"
+#~ msgstr "editar distancia de uso, anulaciÃ³n de sug-mode predeterminada"
 
 #~ msgid "Sorry \"filter\" is currently unimplemented.\n"
-#~ msgstr "Disculpe, pero «filter» no está implementado actualmente.\n"
+#~ msgstr "Disculpe, pero Â«filterÂ» no estÃ¡ implementado actualmente.\n"
 
 #~ msgid "strip accents from word lists"
 #~ msgstr "eliminar acentos de las palabras en vocabulario"
 
-#, fuzzy
 #~ msgid "%where:1: Filter \"%filter:2\" could not be found in filter paths."
-#~ msgstr "No se puede abrir archivo «%file:1» para leer"
+#~ msgstr "%where:1: No se encontrÃ³ el filtro Â«%filter:2Â» en los directorios de filtros."
 
 #~ msgid "enter Html/Sgml mode."
 #~ msgstr "entrar modo Htmp/Sgml"
 
-#, fuzzy
 #~ msgid ""
 #~ "\n"
 #~ "Aspell %s alpha.  Copyright 2000 by Kevin Atkinson.\n"
@@ -1441,17 +1445,17 @@ msgstr "modo para saltarse construcciones tipo URL (modo predeterminado)"
 #~ "Modo de empleo: aspell [opciones] <orden>\n"
 #~ "\n"
 #~ "<orden> es uno de:\n"
-#~ "  -?|help          dar esta lista de ayuda\n"
-#~ "  -c|check <file>  averiguar ortografía de <file>\\n\"\n"
-#~ "  -a|pipe          modo de compatibilidad con «ispell -a»\n"
+#~ "  -?|help          mostrar esta lista de ayuda\n"
+#~ "  -c|check <file>  averiguar ortografÃ­a de <file>\\n\"\n"
+#~ "  -a|pipe          modo de compatibilidad con Â«ispell -aÂ»\n"
 #~ "  -l|list          generar una lista de palabras mal escritas de la entrada\n"
-#~ "                   estándar.\n"
-#~ "  [dump] config    mostrar la configuración corriente en la salida estándar.\n"
-#~ "  config <key>     mostrar el valor de la opción\n"
+#~ "                   estÃ¡ndar.\n"
+#~ "  [dump] config    mostrar la configuraciÃ³n corriente en la salida estÃ¡ndar.\n"
+#~ "  config <key>     mostrar el valor de la opciÃ³n\n"
 #~ "  soundslike       para cada palabra de entrada producir su equivalente\n"
-#~ "                   «soundslike»\n"
-#~ "  filter           pasar la entrada estándar a través del filtro\n"
-#~ "  -v|version       mostrar la versión del programa\n"
+#~ "                   Â«soundslikeÂ»\n"
+#~ "  filter           pasar la entrada estÃ¡ndar a travÃ©s del filtro\n"
+#~ "  -v|version       mostrar la versiÃ³n del programa\n"
 #~ "  dump|create|merge master|personal|repl [vocabulario]\\n\"\n"
 #~ "    mostrar, crear o juntar el vocabulario principal, personal o\n"
 #~ "    de sustituciones.\n"

--- a/po/fi.po
+++ b/po/fi.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aspell 0.60.8-pre2\n"
 "Report-Msgid-Bugs-To: kevina@gnu.org\n"
-"POT-Creation-Date: 2019-09-24 03:02-0400\n"
+"POT-Creation-Date: 2025-06-16 20:23-0500\n"
 "PO-Revision-Date: 2021-02-20 13:12+0200\n"
 "Last-Translator: Jorma Karvonen <karvonen.jorma@gmail.com>\n"
 "Language-Team: Finnish <translation-team-fi@lists.sourceforge.net>\n"
@@ -452,7 +452,6 @@ msgid "The key \"%key:1\" does not take any parameters when prefixed by a \"clea
 msgstr "Valitsin ”%key:1” ei ota mitään parametreja kun sen etuliitteenä on ”clear-”."
 
 #: common/errors.cpp:235
-#, c-format
 msgid "The language \"%lang:1\" is not known."
 msgstr "Kieli ”%lang:1” on tuntematon."
 
@@ -462,17 +461,14 @@ msgid "The soundslike \"%sl:2\" is not known."
 msgstr "Äänenkaltainen ”%sl:2” ei ole tunnettu."
 
 #: common/errors.cpp:251
-#, c-format
 msgid "The language \"%lang:1\" is not supported."
 msgstr "Kieli ”%lang:1” on tukematon."
 
 #: common/errors.cpp:259
-#, c-format
 msgid "No word lists can be found for the language \"%lang:1\"."
 msgstr "Kielelle ”%lang:1” ei löydetty sanaluetteloja."
 
 #: common/errors.cpp:267
-#, c-format
 msgid "Expected language \"%lang:1\" but got \"%prev:2\"."
 msgstr "Odotettiin kieltä ”%lang:1” mutta saatiin ”%prev:2”."
 
@@ -683,7 +679,9 @@ msgid "Invalid Option: %s"
 msgstr "Virheellinen valitsin: %s"
 
 #: prog/aspell.cpp:322
-msgid " does not take any parameters."
+#, fuzzy, c-format
+#| msgid " does not take any parameters."
+msgid "'%s' does not take any parameters."
 msgstr " ei ota parametrejä."
 
 #: prog/aspell.cpp:335 prog/aspell.cpp:395
@@ -938,10 +936,14 @@ msgid "  <norm-form>      normalization form to use, either none, internal, or s
 msgstr "  <normalisointimuoto> käytettävä normalisointimuoto on joko none, internal, tai strict"
 
 #: prog/aspell.cpp:2884
-#, c-format
+#, fuzzy, c-format
+#| msgid ""
+#| "\n"
+#| "Aspell %s.  Copyright 2000-2019 by Kevin Atkinson.\n"
+#| "\n"
 msgid ""
 "\n"
-"Aspell %s.  Copyright 2000-2019 by Kevin Atkinson.\n"
+"Aspell %s.  Copyright 2000-2023 by Kevin Atkinson.\n"
 "\n"
 msgstr ""
 "\n"
@@ -1205,7 +1207,7 @@ msgstr "Kokonaissanapituus, äänenkaltaisella tiedolla, on laajempi kuin 240 me
 msgid "There must be at least one \"add\" line."
 msgstr "On oltava vähintään yksi ”add”-rivi."
 
-#: modules/speller/default/suggest.cpp:1720
+#: modules/speller/default/suggest.cpp:1730
 msgid "one of ultra, fast, normal, slow, or bad-spellers"
 msgstr "yksi seuraavista: ultra, fast, normal, slow tai bad-spellers"
 
@@ -1292,6 +1294,16 @@ msgstr "HTML-tunnisteet, jotka aloittavat HTML-lohkon,joka päättyy tyhjään r
 msgid "filter for dealing with Nroff documents"
 msgstr "suodatin Nroff-asiakirjojen käsittelemiseen"
 
+#: modules/filter/po-filter.info:7
+#, fuzzy
+#| msgid "filter for dealing with Texinfo documents"
+msgid "filter to deal with gettext .po files"
+msgstr "suodatin Texinfo-asiakirjojen käsittelemiseen"
+
+#: modules/filter/po-filter.info:13
+msgid "review only msgids"
+msgstr ""
+
 #: modules/filter/sgml-filter.info:9
 msgid "filter for dealing with generic SGML/XML documents"
 msgstr "suodatin yleisten SGML/XML -asiakirjojen käsittelemiseen"
@@ -1363,6 +1375,12 @@ msgstr "tila Nroff-asiakirjojen tarkistamiseen"
 #: modules/filter/modes/perl.amf:8
 msgid "mode for checking Perl comments and string literals"
 msgstr "tila Perl-kommenttien ja merkkijonoliteraalien tarkistamiseen"
+
+#: modules/filter/modes/po.amf:7
+#, fuzzy
+#| msgid "mode for checking Texinfo documents"
+msgid "mode for checking gettext .po files"
+msgstr "tila Texinfo-asiakirjojen tarkistamiseen"
 
 #: modules/filter/modes/sgml.amf:8
 msgid "mode for checking generic SGML/XML documents"

--- a/po/fr.po
+++ b/po/fr.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aspell 0.60.8.1\n"
 "Report-Msgid-Bugs-To: kevina@gnu.org\n"
-"POT-Creation-Date: 2023-12-03 01:21-0500\n"
+"POT-Creation-Date: 2025-06-16 20:23-0500\n"
 "PO-Revision-Date: 2023-12-03 10:55+0200\n"
 "Last-Translator: Thierry Thomas <thierry@pompo.net>\n"
 "Language-Team: French <traduc@traduc.org>\n"
@@ -455,7 +455,6 @@ msgid "The key \"%key:1\" does not take any parameters when prefixed by a \"clea
 msgstr "La clef « %key:1 » n’a pas de paramètre si elle est préfixée par « clear- »."
 
 #: common/errors.cpp:235
-#, c-format
 msgid "The language \"%lang:1\" is not known."
 msgstr "La langue « %lang:1 » est inconnue."
 
@@ -465,17 +464,14 @@ msgid "The soundslike \"%sl:2\" is not known."
 msgstr "Le phonème « %sl:2 » est inconnu."
 
 #: common/errors.cpp:251
-#, c-format
 msgid "The language \"%lang:1\" is not supported."
 msgstr "La langue « %lang:1 » n’est pas supportée."
 
 #: common/errors.cpp:259
-#, c-format
 msgid "No word lists can be found for the language \"%lang:1\"."
 msgstr "Aucun dictionnaire n’a pu être trouvé pour la langue « %lang:1 »."
 
 #: common/errors.cpp:267
-#, c-format
 msgid "Expected language \"%lang:1\" but got \"%prev:2\"."
 msgstr "La langue attendue était « %lang:1 » mais « %prev:2 » a été rencontrée."
 
@@ -1306,6 +1302,16 @@ msgstr "balises HTML débutant par un bloc se terminant avec une ligne blanche"
 msgid "filter for dealing with Nroff documents"
 msgstr "filtre pour traiter les documents Nroff"
 
+#: modules/filter/po-filter.info:7
+#, fuzzy
+#| msgid "filter for dealing with Texinfo documents"
+msgid "filter to deal with gettext .po files"
+msgstr "filtre pour traiter les documents Texinfo"
+
+#: modules/filter/po-filter.info:13
+msgid "review only msgids"
+msgstr ""
+
 #: modules/filter/sgml-filter.info:9
 msgid "filter for dealing with generic SGML/XML documents"
 msgstr "filtre pour les documents SGML/XML"
@@ -1377,6 +1383,12 @@ msgstr "mode de vérif. des pages Nroff"
 #: modules/filter/modes/perl.amf:8
 msgid "mode for checking Perl comments and string literals"
 msgstr "mode de vérif. des commentaires et chaînes Perl"
+
+#: modules/filter/modes/po.amf:7
+#, fuzzy
+#| msgid "mode for checking Texinfo documents"
+msgid "mode for checking gettext .po files"
+msgstr "mode de vérif. des documents Texinfo"
 
 #: modules/filter/modes/sgml.amf:8
 msgid "mode for checking generic SGML/XML documents"

--- a/po/fur.po
+++ b/po/fur.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aspell 0.60.8-pre2\n"
 "Report-Msgid-Bugs-To: kevina@gnu.org\n"
-"POT-Creation-Date: 2019-09-24 03:02-0400\n"
+"POT-Creation-Date: 2025-06-16 20:23-0500\n"
 "PO-Revision-Date: 2023-01-21 07:10+0000\n"
 "Last-Translator: Fabio T. <f.t.public@gmail.com>\n"
 "Language-Team: Friulian <f.t.public@gmail.com>\n"
@@ -451,7 +451,6 @@ msgid "The key \"%key:1\" does not take any parameters when prefixed by a \"clea
 msgstr "La clâf \"%key:1\" no vûl nissun parametri cuant che si met denant un \"clear-\"."
 
 #: common/errors.cpp:235
-#, c-format
 msgid "The language \"%lang:1\" is not known."
 msgstr "La lenghe \"%lang:1\" no je cognossude."
 
@@ -461,17 +460,14 @@ msgid "The soundslike \"%sl:2\" is not known."
 msgstr "Il foneme \"%sl:2\" nol è cognossût."
 
 #: common/errors.cpp:251
-#, c-format
 msgid "The language \"%lang:1\" is not supported."
 msgstr "La lenghe \"%lang:1\" no je supuartade."
 
 #: common/errors.cpp:259
-#, c-format
 msgid "No word lists can be found for the language \"%lang:1\"."
 msgstr "Nissune liste di peraulis e pues jessi cjatade pe lenghe \"%lang:1\"."
 
 #: common/errors.cpp:267
-#, c-format
 msgid "Expected language \"%lang:1\" but got \"%prev:2\"."
 msgstr "Si spietave la lenghe \"%lang:1\" ma si à vût \"%prev:2\"."
 
@@ -682,7 +678,9 @@ msgid "Invalid Option: %s"
 msgstr "Opzion no valide: %s"
 
 #: prog/aspell.cpp:322
-msgid " does not take any parameters."
+#, fuzzy, c-format
+#| msgid " does not take any parameters."
+msgid "'%s' does not take any parameters."
 msgstr " nol cjape nissun parametri."
 
 #: prog/aspell.cpp:335 prog/aspell.cpp:395
@@ -935,10 +933,14 @@ msgid "  <norm-form>      normalization form to use, either none, internal, or s
 msgstr "  <forme-norm>      forme di normalizazion di doprâ, che e sedi none, internal, o strict"
 
 #: prog/aspell.cpp:2884
-#, c-format
+#, fuzzy, c-format
+#| msgid ""
+#| "\n"
+#| "Aspell %s.  Copyright 2000-2019 by Kevin Atkinson.\n"
+#| "\n"
 msgid ""
 "\n"
-"Aspell %s.  Copyright 2000-2019 by Kevin Atkinson.\n"
+"Aspell %s.  Copyright 2000-2023 by Kevin Atkinson.\n"
 "\n"
 msgstr ""
 "\n"
@@ -1202,7 +1204,7 @@ msgstr "La lungjece totâl de peraule, cui dâts foneme, e je plui grande di 240
 msgid "There must be at least one \"add\" line."
 msgstr "E scugne jessi almancul une rie \"add\"."
 
-#: modules/speller/default/suggest.cpp:1720
+#: modules/speller/default/suggest.cpp:1730
 msgid "one of ultra, fast, normal, slow, or bad-spellers"
 msgstr "un di ultra, fast, normal, slow o bad-spellers"
 
@@ -1289,6 +1291,16 @@ msgstr "etichetis HTML che a scomencin un bloc HTML che al finìs cuntune rie vu
 msgid "filter for dealing with Nroff documents"
 msgstr "filtri par vê a ce fâ cui documents Nroff"
 
+#: modules/filter/po-filter.info:7
+#, fuzzy
+#| msgid "filter for dealing with Texinfo documents"
+msgid "filter to deal with gettext .po files"
+msgstr "filtri par vê a ce fâ cui documents Texinfo"
+
+#: modules/filter/po-filter.info:13
+msgid "review only msgids"
+msgstr ""
+
 #: modules/filter/sgml-filter.info:9
 msgid "filter for dealing with generic SGML/XML documents"
 msgstr "filtri par vê a ce fâ cui documents gjenerics SGML/XML"
@@ -1360,6 +1372,12 @@ msgstr "modalitât par controlâ i documents Nroff"
 #: modules/filter/modes/perl.amf:8
 msgid "mode for checking Perl comments and string literals"
 msgstr "modalitât par controlâ i coments Perl e i leterâi di stringhe"
+
+#: modules/filter/modes/po.amf:7
+#, fuzzy
+#| msgid "mode for checking Texinfo documents"
+msgid "mode for checking gettext .po files"
+msgstr "modalitât par controlâ i documents Texinfo"
 
 #: modules/filter/modes/sgml.amf:8
 msgid "mode for checking generic SGML/XML documents"

--- a/po/ga.po
+++ b/po/ga.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aspell 0.60.7\n"
 "Report-Msgid-Bugs-To: kevina@gnu.org\n"
-"POT-Creation-Date: 2023-12-19 16:19-0500\n"
+"POT-Creation-Date: 2025-06-16 20:23-0500\n"
 "PO-Revision-Date: 2013-05-09 06:24-05:00\n"
 "Last-Translator: Kevin Patrick Scannell <kscanne@gmail.com>\n"
 "Language-Team: Irish <gaeilge-gnulinux@lists.sourceforge.net>\n"
@@ -449,7 +449,6 @@ msgid "The key \"%key:1\" does not take any parameters when prefixed by a \"clea
 msgstr "Ní ghlacann eochair \"%key:1\" le haon pharaiméadar nuair atá réimír \"clear-\" uirthi."
 
 #: common/errors.cpp:235
-#, c-format
 msgid "The language \"%lang:1\" is not known."
 msgstr "Níl an teanga \"%lang:1\" ar fáil."
 
@@ -459,17 +458,14 @@ msgid "The soundslike \"%sl:2\" is not known."
 msgstr "Níl an comhad `soundslike' \"%sl:2\" ar fáil."
 
 #: common/errors.cpp:251
-#, c-format
 msgid "The language \"%lang:1\" is not supported."
 msgstr "Níl an teanga \"%lang:1\" ar fáil."
 
 #: common/errors.cpp:259
-#, c-format
 msgid "No word lists can be found for the language \"%lang:1\"."
 msgstr "Níl aon liosta focal le haghaidh na teanga \"%lang:1\"."
 
 #: common/errors.cpp:267
-#, c-format
 msgid "Expected language \"%lang:1\" but got \"%prev:2\"."
 msgstr "Bhíothas ag súil leis an teanga \"%lang:1\" ach fuarthas \"%prev:2\"."
 
@@ -1299,6 +1295,16 @@ msgstr ""
 msgid "filter for dealing with Nroff documents"
 msgstr "scagaire le haghaidh cáipéisí Nroff"
 
+#: modules/filter/po-filter.info:7
+#, fuzzy
+#| msgid "filter for dealing with Texinfo documents"
+msgid "filter to deal with gettext .po files"
+msgstr "scagaire le haghaidh cáipéisí Texinfo"
+
+#: modules/filter/po-filter.info:13
+msgid "review only msgids"
+msgstr ""
+
 #: modules/filter/sgml-filter.info:9
 msgid "filter for dealing with generic SGML/XML documents"
 msgstr "scagaire le haghaidh cáipéisí SGML/XML ginearálta"
@@ -1372,6 +1378,12 @@ msgstr "mód a sheiceálann cáipéisí Nroff"
 #: modules/filter/modes/perl.amf:8
 msgid "mode for checking Perl comments and string literals"
 msgstr "mód a sheiceálann nótaí tráchta agus teaghráin i bPerl"
+
+#: modules/filter/modes/po.amf:7
+#, fuzzy
+#| msgid "mode for checking Texinfo documents"
+msgid "mode for checking gettext .po files"
+msgstr "mód a sheiceálann cáipéisí Texinfo"
 
 #: modules/filter/modes/sgml.amf:8
 msgid "mode for checking generic SGML/XML documents"

--- a/po/hr.po
+++ b/po/hr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aspell-0.60.8.1\n"
 "Report-Msgid-Bugs-To: kevina@gnu.org\n"
-"POT-Creation-Date: 2023-12-03 01:21-0500\n"
+"POT-Creation-Date: 2025-06-16 20:23-0500\n"
 "PO-Revision-Date: 2023-12-04 21:13-0800\n"
 "Last-Translator: Božidar Putanec <bozidarp@yahoo.com>\n"
 "Language-Team: Croatian <lokalizacija@linux.hr>\n"
@@ -454,7 +454,6 @@ msgid "The key \"%key:1\" does not take any parameters when prefixed by a \"clea
 msgstr "Ključ „%key:1“ ne prihvaća nijedan parametar kad ima prefiks „clear-“."
 
 #: common/errors.cpp:235
-#, c-format
 msgid "The language \"%lang:1\" is not known."
 msgstr "Jezik „%lang:1“ nije poznat."
 
@@ -464,17 +463,14 @@ msgid "The soundslike \"%sl:2\" is not known."
 msgstr "Zvučnost riječi „%sl:2“ nije poznata."
 
 #: common/errors.cpp:251
-#, c-format
 msgid "The language \"%lang:1\" is not supported."
 msgstr "Jezik „%lang:1“ nije podržan."
 
 #: common/errors.cpp:259
-#, c-format
 msgid "No word lists can be found for the language \"%lang:1\"."
 msgstr "Nije moguće pronaći popis riječi za jezik „%lang:1“."
 
 #: common/errors.cpp:267
-#, c-format
 msgid "Expected language \"%lang:1\" but got \"%prev:2\"."
 msgstr "Očekivan je jezik „%lang:1“, dobiven je „%prev:2“."
 
@@ -1293,6 +1289,16 @@ msgstr "HTML oznake na početku HTML bloka koje završavaju s praznim retkom"
 msgid "filter for dealing with Nroff documents"
 msgstr "filtar za rad s Nroff dokumentima"
 
+#: modules/filter/po-filter.info:7
+#, fuzzy
+#| msgid "filter for dealing with Texinfo documents"
+msgid "filter to deal with gettext .po files"
+msgstr "filtar za rad s Texinfo dokumentima"
+
+#: modules/filter/po-filter.info:13
+msgid "review only msgids"
+msgstr ""
+
 #: modules/filter/sgml-filter.info:9
 msgid "filter for dealing with generic SGML/XML documents"
 msgstr "filtar za rad s općim SGML/XML dokumentima"
@@ -1364,6 +1370,12 @@ msgstr "za provjeravanje Nroff dokumenata"
 #: modules/filter/modes/perl.amf:8
 msgid "mode for checking Perl comments and string literals"
 msgstr "za provjeru Perl komentara i (doslovnih) stringova"
+
+#: modules/filter/modes/po.amf:7
+#, fuzzy
+#| msgid "mode for checking Texinfo documents"
+msgid "mode for checking gettext .po files"
+msgstr "za provjeru Texinfo dokumenata"
 
 #: modules/filter/modes/sgml.amf:8
 msgid "mode for checking generic SGML/XML documents"

--- a/po/hu.po
+++ b/po/hu.po
@@ -8,15 +8,15 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aspell 0.60.8-pre2\n"
 "Report-Msgid-Bugs-To: kevina@gnu.org\n"
-"POT-Creation-Date: 2019-09-24 03:02-0400\n"
+"POT-Creation-Date: 2025-06-16 20:23-0500\n"
 "PO-Revision-Date: 2023-10-04 14:32+0200\n"
 "Last-Translator: Balázs Úr <ur.balazs@fsf.hu>\n"
 "Language-Team: Hungarian <translation-team-hu@lists.sourceforge.net>\n"
 "Language: hu\n"
-"X-Bugs: Report translation errors to the Language-Team address.\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"X-Bugs: Report translation errors to the Language-Team address.\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Lokalize 23.04.3\n"
 
@@ -451,7 +451,6 @@ msgid "The key \"%key:1\" does not take any parameters when prefixed by a \"clea
 msgstr "A(z) „%key:1” kulcs nem fogad el semmilyen paramétert, ha „clear-” előtagot kapott."
 
 #: common/errors.cpp:235
-#, c-format
 msgid "The language \"%lang:1\" is not known."
 msgstr "A(z) „%lang:1” nyelv nem ismert."
 
@@ -461,17 +460,14 @@ msgid "The soundslike \"%sl:2\" is not known."
 msgstr "A(z) „%sl:2” hangzásbeli megfelelő nem ismert."
 
 #: common/errors.cpp:251
-#, c-format
 msgid "The language \"%lang:1\" is not supported."
 msgstr "A(z) „%lang:1” nyelv nem támogatott."
 
 #: common/errors.cpp:259
-#, c-format
 msgid "No word lists can be found for the language \"%lang:1\"."
 msgstr "Nem találhatók szólisták a(z) „%lang:1” nyelvhez."
 
 #: common/errors.cpp:267
-#, c-format
 msgid "Expected language \"%lang:1\" but got \"%prev:2\"."
 msgstr "A(z) „%lang:1” nyelv az elvárt, de „%prev:2” érkezett."
 
@@ -682,7 +678,9 @@ msgid "Invalid Option: %s"
 msgstr "Érvénytelen kapcsoló: %s"
 
 #: prog/aspell.cpp:322
-msgid " does not take any parameters."
+#, fuzzy, c-format
+#| msgid " does not take any parameters."
+msgid "'%s' does not take any parameters."
 msgstr " nem fogad el semmilyen paramétert."
 
 #: prog/aspell.cpp:335 prog/aspell.cpp:395
@@ -935,10 +933,14 @@ msgid "  <norm-form>      normalization form to use, either none, internal, or s
 msgstr "  <norm-forma>    a használandó normalizálási forma, „none”, „internal” vagy „strict”"
 
 #: prog/aspell.cpp:2884
-#, c-format
+#, fuzzy, c-format
+#| msgid ""
+#| "\n"
+#| "Aspell %s.  Copyright 2000-2019 by Kevin Atkinson.\n"
+#| "\n"
 msgid ""
 "\n"
-"Aspell %s.  Copyright 2000-2019 by Kevin Atkinson.\n"
+"Aspell %s.  Copyright 2000-2023 by Kevin Atkinson.\n"
 "\n"
 msgstr ""
 "\n"
@@ -1200,7 +1202,7 @@ msgstr "A teljes szóhossz a hangzásbeli megfelelő adataival együtt meghaladj
 msgid "There must be at least one \"add\" line."
 msgstr "Legalább egy „add” sornak lennie kell."
 
-#: modules/speller/default/suggest.cpp:1720
+#: modules/speller/default/suggest.cpp:1730
 msgid "one of ultra, fast, normal, slow, or bad-spellers"
 msgstr "az „ultra”, „fast”, „normal”, „slow” vagy „bad-spellers” egyike"
 
@@ -1287,6 +1289,16 @@ msgstr "HTML-címkék, amelyek olyan HTML-blokkot kezdenek, amely üres sorral v
 msgid "filter for dealing with Nroff documents"
 msgstr "szűrő az Nroff-dokumentumok kezeléséhez"
 
+#: modules/filter/po-filter.info:7
+#, fuzzy
+#| msgid "filter for dealing with Texinfo documents"
+msgid "filter to deal with gettext .po files"
+msgstr "szűrő a Texinfo-dokumentumok kezeléséhez"
+
+#: modules/filter/po-filter.info:13
+msgid "review only msgids"
+msgstr ""
+
 #: modules/filter/sgml-filter.info:9
 msgid "filter for dealing with generic SGML/XML documents"
 msgstr "szűrő az általános SGML/XML-dokumentumok kezeléséhez"
@@ -1358,6 +1370,12 @@ msgstr "egy mód az Nroff-dokumentumok ellenőrzéséhez"
 #: modules/filter/modes/perl.amf:8
 msgid "mode for checking Perl comments and string literals"
 msgstr "egy mód a Perl megjegyzések és karakterlánc-literálok ellenőrzéséhez"
+
+#: modules/filter/modes/po.amf:7
+#, fuzzy
+#| msgid "mode for checking Texinfo documents"
+msgid "mode for checking gettext .po files"
+msgstr "egy mód a Texinfo-dokumentumok ellenőrzéséhez"
 
 #: modules/filter/modes/sgml.amf:8
 msgid "mode for checking generic SGML/XML documents"

--- a/po/id.po
+++ b/po/id.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aspell 0.60.8.1\n"
 "Report-Msgid-Bugs-To: kevina@gnu.org\n"
-"POT-Creation-Date: 2023-12-03 01:21-0500\n"
+"POT-Creation-Date: 2025-06-16 20:23-0500\n"
 "PO-Revision-Date: 2023-12-06 09:45+0700\n"
 "Last-Translator: Andika Triwidada <andika@gmail.com>\n"
 "Language-Team: Indonesian <translation-team-id@lists.sourceforge.net>\n"
@@ -451,7 +451,6 @@ msgid "The key \"%key:1\" does not take any parameters when prefixed by a \"clea
 msgstr "Tombol \"%key:1\" tidak mengambil parameter apapun ketika diawali dengan sebuah \"clear-\"."
 
 #: common/errors.cpp:235
-#, c-format
 msgid "The language \"%lang:1\" is not known."
 msgstr "Bahasa \"%lang:1\" tidak diketahui."
 
@@ -461,17 +460,14 @@ msgid "The soundslike \"%sl:2\" is not known."
 msgstr "Sounslike \"%sl:2\" tidak diketahui."
 
 #: common/errors.cpp:251
-#, c-format
 msgid "The language \"%lang:1\" is not supported."
 msgstr "Bahasa \"%lang:1\" tidak didukung."
 
 #: common/errors.cpp:259
-#, c-format
 msgid "No word lists can be found for the language \"%lang:1\"."
 msgstr "Tidak ada daftar kata yang dapat ditemukan untuk bahasa \"%lang:1\"."
 
 #: common/errors.cpp:267
-#, c-format
 msgid "Expected language \"%lang:1\" but got \"%prev:2\"."
 msgstr "Bahasa yang diduga \"%lang:1\" tetapi diperoleh \"%prev:2\"."
 
@@ -1296,6 +1292,16 @@ msgstr "tag HTML yang memulai blok HTML yang diakhiri dengan baris kosong"
 msgid "filter for dealing with Nroff documents"
 msgstr "penyaring untuk menghadapi dengan dokumen Nroff"
 
+#: modules/filter/po-filter.info:7
+#, fuzzy
+#| msgid "filter for dealing with Texinfo documents"
+msgid "filter to deal with gettext .po files"
+msgstr "penyaring untuk menangani dokumen Texinfo"
+
+#: modules/filter/po-filter.info:13
+msgid "review only msgids"
+msgstr ""
+
 #: modules/filter/sgml-filter.info:9
 msgid "filter for dealing with generic SGML/XML documents"
 msgstr "penyaring untuk menghadapi dengan dokumen generik SGML/XML"
@@ -1367,6 +1373,12 @@ msgstr "mode untuk pemeriksaan dokumen Nroff"
 #: modules/filter/modes/perl.amf:8
 msgid "mode for checking Perl comments and string literals"
 msgstr "mode untuk pemeriksaan komentar Perl dan string literals"
+
+#: modules/filter/modes/po.amf:7
+#, fuzzy
+#| msgid "mode for checking Texinfo documents"
+msgid "mode for checking gettext .po files"
+msgstr "mode untuk pemeriksaan dokumen Texinfo"
 
 #: modules/filter/modes/sgml.amf:8
 msgid "mode for checking generic SGML/XML documents"

--- a/po/it.po
+++ b/po/it.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aspell 0.60.8-pre2\n"
 "Report-Msgid-Bugs-To: kevina@gnu.org\n"
-"POT-Creation-Date: 2019-09-24 03:02-0400\n"
+"POT-Creation-Date: 2025-06-16 20:23-0500\n"
 "PO-Revision-Date: 2020-03-07 15:33+0100\n"
 "Last-Translator: Francesco Groccia <fg@snopyta.org>\n"
 "Language-Team: Italian <tp@lists.linux.it>\n"
@@ -452,7 +452,6 @@ msgid "The key \"%key:1\" does not take any parameters when prefixed by a \"clea
 msgstr "L'opzione \"%key:1\" non accetta parametri quando è prefissata da \"clear-\"."
 
 #: common/errors.cpp:235
-#, c-format
 msgid "The language \"%lang:1\" is not known."
 msgstr "La lingua \"%lang:1\" è sconosciuta."
 
@@ -462,17 +461,14 @@ msgid "The soundslike \"%sl:2\" is not known."
 msgstr "Il soundslike \"%sl:2\" è sconosciuto."
 
 #: common/errors.cpp:251
-#, c-format
 msgid "The language \"%lang:1\" is not supported."
 msgstr "La lingua \"%lang:1\" non è supportata."
 
 #: common/errors.cpp:259
-#, c-format
 msgid "No word lists can be found for the language \"%lang:1\"."
 msgstr "Non è possibile trovare alcuna lista di parole per la lingua \"%lang:1\"."
 
 #: common/errors.cpp:267
-#, c-format
 msgid "Expected language \"%lang:1\" but got \"%prev:2\"."
 msgstr "Invece della lingua \"%lang:1\" trovato \"%prev:2\"."
 
@@ -683,7 +679,9 @@ msgid "Invalid Option: %s"
 msgstr "Opzione non valida: %s"
 
 #: prog/aspell.cpp:322
-msgid " does not take any parameters."
+#, fuzzy, c-format
+#| msgid " does not take any parameters."
+msgid "'%s' does not take any parameters."
 msgstr "non accetta alcun parametro."
 
 #: prog/aspell.cpp:335 prog/aspell.cpp:395
@@ -936,10 +934,14 @@ msgid "  <norm-form>      normalization form to use, either none, internal, or s
 msgstr "  <norm-form>      normalizzazione da usare: essere \"none\", \"internal\", o \"strict\""
 
 #: prog/aspell.cpp:2884
-#, c-format
+#, fuzzy, c-format
+#| msgid ""
+#| "\n"
+#| "Aspell %s.  Copyright 2000-2019 by Kevin Atkinson.\n"
+#| "\n"
 msgid ""
 "\n"
-"Aspell %s.  Copyright 2000-2019 by Kevin Atkinson.\n"
+"Aspell %s.  Copyright 2000-2023 by Kevin Atkinson.\n"
 "\n"
 msgstr ""
 "\n"
@@ -1202,7 +1204,7 @@ msgstr "La lunghezza totale della parola, con i dati soundslike, supera i 240 ca
 msgid "There must be at least one \"add\" line."
 msgstr "Deve esserci almeno una riga \"add\"."
 
-#: modules/speller/default/suggest.cpp:1720
+#: modules/speller/default/suggest.cpp:1730
 msgid "one of ultra, fast, normal, slow, or bad-spellers"
 msgstr "ultra, fast, normal, slow, o bad-spellers"
 
@@ -1289,6 +1291,16 @@ msgstr "tag HTML che iniziano un blocco HTML che finisce con una linea vuota"
 msgid "filter for dealing with Nroff documents"
 msgstr "filtro per i documenti Nroff"
 
+#: modules/filter/po-filter.info:7
+#, fuzzy
+#| msgid "filter for dealing with Texinfo documents"
+msgid "filter to deal with gettext .po files"
+msgstr "filtro per i documenti Texinfo"
+
+#: modules/filter/po-filter.info:13
+msgid "review only msgids"
+msgstr ""
+
 #: modules/filter/sgml-filter.info:9
 msgid "filter for dealing with generic SGML/XML documents"
 msgstr "filtro per i documenti SGML/XML"
@@ -1360,6 +1372,12 @@ msgstr "modalità per controllare i documenti Nroff"
 #: modules/filter/modes/perl.amf:8
 msgid "mode for checking Perl comments and string literals"
 msgstr "modalità per controllare i commenti Perl e le stringhe letterali"
+
+#: modules/filter/modes/po.amf:7
+#, fuzzy
+#| msgid "mode for checking Texinfo documents"
+msgid "mode for checking gettext .po files"
+msgstr "modalità per controllare i documenti Texinfo"
 
 #: modules/filter/modes/sgml.amf:8
 msgid "mode for checking generic SGML/XML documents"

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aspell 0.60.8-pre1\n"
 "Report-Msgid-Bugs-To: kevina@gnu.org\n"
-"POT-Creation-Date: 2023-12-19 16:19-0500\n"
+"POT-Creation-Date: 2025-06-16 20:23-0500\n"
 "PO-Revision-Date: 2019-09-24 01:21+0900\n"
 "Last-Translator: Takeshi Hamasaki <hmatrjp@users.sourceforge.jp>\n"
 "Language-Team: Japanese <translation-team-ja@lists.sourceforge.net>\n"
@@ -450,7 +450,6 @@ msgid "The key \"%key:1\" does not take any parameters when prefixed by a \"clea
 msgstr "キー \"%key:1\" は \"clear-\" が前に付いている時にはパラメータを取りません。"
 
 #: common/errors.cpp:235
-#, c-format
 msgid "The language \"%lang:1\" is not known."
 msgstr "言語 \"%lang:1\" は未知です。"
 
@@ -460,17 +459,14 @@ msgid "The soundslike \"%sl:2\" is not known."
 msgstr "疑似音声 \"%sl:2\" は未知です。"
 
 #: common/errors.cpp:251
-#, c-format
 msgid "The language \"%lang:1\" is not supported."
 msgstr "言語 \"%lang:1\" をサポートしていません。"
 
 #: common/errors.cpp:259
-#, c-format
 msgid "No word lists can be found for the language \"%lang:1\"."
 msgstr "言語 \"%lang:1\" の単語リストが見つかりません."
 
 #: common/errors.cpp:267
-#, c-format
 msgid "Expected language \"%lang:1\" but got \"%prev:2\"."
 msgstr "言語 \"%lang:1\" を予期していましたが、 \"%prev:2\" でした."
 
@@ -1297,6 +1293,16 @@ msgstr "空行で終わるHTMLブロックを開始するHTMLタグ"
 msgid "filter for dealing with Nroff documents"
 msgstr "Nroff文書のためのフィルタ"
 
+#: modules/filter/po-filter.info:7
+#, fuzzy
+#| msgid "filter for dealing with Texinfo documents"
+msgid "filter to deal with gettext .po files"
+msgstr "Texinfo文書のためのフィルタ"
+
+#: modules/filter/po-filter.info:13
+msgid "review only msgids"
+msgstr ""
+
 #: modules/filter/sgml-filter.info:9
 msgid "filter for dealing with generic SGML/XML documents"
 msgstr "一般のSGML/XML文書のためのフィルタ"
@@ -1368,6 +1374,12 @@ msgstr "Nroff文書をチェックするためのモード"
 #: modules/filter/modes/perl.amf:8
 msgid "mode for checking Perl comments and string literals"
 msgstr "Perlのコメントと文字列をチェックするためのモード"
+
+#: modules/filter/modes/po.amf:7
+#, fuzzy
+#| msgid "mode for checking Texinfo documents"
+msgid "mode for checking gettext .po files"
+msgstr "Texinfo文書をチェックするためのモード"
 
 #: modules/filter/modes/sgml.amf:8
 msgid "mode for checking generic SGML/XML documents"

--- a/po/ka.po
+++ b/po/ka.po
@@ -7,15 +7,15 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aspell 0.60.8-pre2\n"
 "Report-Msgid-Bugs-To: kevina@gnu.org\n"
-"POT-Creation-Date: 2019-09-24 03:02-0400\n"
+"POT-Creation-Date: 2025-06-16 20:23-0500\n"
 "PO-Revision-Date: 2023-03-10 05:53+0100\n"
 "Last-Translator: Temuri Doghonadze <temuri.doghonadze@gmail.com>\n"
 "Language-Team: Georgian <(nothing)>\n"
 "Language: ka\n"
-"X-Bugs: Report translation errors to the Language-Team address.\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"X-Bugs: Report translation errors to the Language-Team address.\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.2.2\n"
 
@@ -450,7 +450,6 @@ msgid "The key \"%key:1\" does not take any parameters when prefixed by a \"clea
 msgstr ""
 
 #: common/errors.cpp:235
-#, c-format
 msgid "The language \"%lang:1\" is not known."
 msgstr "ენა \"%lang:1\" უცნობია."
 
@@ -460,17 +459,14 @@ msgid "The soundslike \"%sl:2\" is not known."
 msgstr "Soundslike \"%sl:2\" უცნობია."
 
 #: common/errors.cpp:251
-#, c-format
 msgid "The language \"%lang:1\" is not supported."
 msgstr "ენა \"%lang:1\" მხარდაუჭერელია."
 
 #: common/errors.cpp:259
-#, c-format
 msgid "No word lists can be found for the language \"%lang:1\"."
 msgstr ""
 
 #: common/errors.cpp:267
-#, c-format
 msgid "Expected language \"%lang:1\" but got \"%prev:2\"."
 msgstr ""
 
@@ -681,7 +677,9 @@ msgid "Invalid Option: %s"
 msgstr "არასწორი პარამეტრი: %s"
 
 #: prog/aspell.cpp:322
-msgid " does not take any parameters."
+#, fuzzy, c-format
+#| msgid " does not take any parameters."
+msgid "'%s' does not take any parameters."
 msgstr " არ იღებს პარამეტრებს."
 
 #: prog/aspell.cpp:335 prog/aspell.cpp:395
@@ -934,10 +932,14 @@ msgid "  <norm-form>      normalization form to use, either none, internal, or s
 msgstr ""
 
 #: prog/aspell.cpp:2884
-#, c-format
+#, fuzzy, c-format
+#| msgid ""
+#| "\n"
+#| "Aspell %s.  Copyright 2000-2019 by Kevin Atkinson.\n"
+#| "\n"
 msgid ""
 "\n"
-"Aspell %s.  Copyright 2000-2019 by Kevin Atkinson.\n"
+"Aspell %s.  Copyright 2000-2023 by Kevin Atkinson.\n"
 "\n"
 msgstr ""
 "\n"
@@ -1189,7 +1191,7 @@ msgstr ""
 msgid "There must be at least one \"add\" line."
 msgstr ""
 
-#: modules/speller/default/suggest.cpp:1720
+#: modules/speller/default/suggest.cpp:1730
 msgid "one of ultra, fast, normal, slow, or bad-spellers"
 msgstr ""
 
@@ -1276,6 +1278,14 @@ msgstr ""
 msgid "filter for dealing with Nroff documents"
 msgstr ""
 
+#: modules/filter/po-filter.info:7
+msgid "filter to deal with gettext .po files"
+msgstr ""
+
+#: modules/filter/po-filter.info:13
+msgid "review only msgids"
+msgstr ""
+
 #: modules/filter/sgml-filter.info:9
 msgid "filter for dealing with generic SGML/XML documents"
 msgstr ""
@@ -1346,6 +1356,10 @@ msgstr ""
 
 #: modules/filter/modes/perl.amf:8
 msgid "mode for checking Perl comments and string literals"
+msgstr ""
+
+#: modules/filter/modes/po.amf:7
+msgid "mode for checking gettext .po files"
 msgstr ""
 
 #: modules/filter/modes/sgml.amf:8

--- a/po/mn.po
+++ b/po/mn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aspell 0.60-pre1\n"
 "Report-Msgid-Bugs-To: kevina@gnu.org\n"
-"POT-Creation-Date: 2023-12-19 16:19-0500\n"
+"POT-Creation-Date: 2025-06-16 20:23-0500\n"
 "PO-Revision-Date: 2004-07-24 11:18+0100\n"
 "Last-Translator: Sanlig Badral <badral@users.sourceforge.net>\n"
 "Language-Team: Mongolian <openmn-translation@lists.sourceforge.net>\n"
@@ -465,7 +465,6 @@ msgid "The key \"%key:1\" does not take any parameters when prefixed by a \"clea
 msgstr "\"%key:1\" түлхүүр \"clear-\" -ээр эхэлсэн бол ямарч параметер авахгүй."
 
 #: common/errors.cpp:235
-#, c-format
 msgid "The language \"%lang:1\" is not known."
 msgstr "\"%lang:1\" хэл мэдэгдсэнгүй."
 
@@ -475,17 +474,14 @@ msgid "The soundslike \"%sl:2\" is not known."
 msgstr "Үл мэдэгдэх \"%sl:2\" авиа."
 
 #: common/errors.cpp:251
-#, c-format
 msgid "The language \"%lang:1\" is not supported."
 msgstr "\"%lang:1\" хэл дэмжигдээгүй."
 
 #: common/errors.cpp:259
-#, c-format
 msgid "No word lists can be found for the language \"%lang:1\"."
 msgstr "\"%lang:1\" хэлний хувьд үгийн жагсаалт олдсонгүй."
 
 #: common/errors.cpp:267
-#, c-format
 msgid "Expected language \"%lang:1\" but got \"%prev:2\"."
 msgstr "Хүлээгдсэн хэл \"%lang:1\" харин \"%prev:2\" -г авчээ."
 
@@ -1348,6 +1344,16 @@ msgstr ""
 msgid "filter for dealing with Nroff documents"
 msgstr "HTML баримтуудтай холбоотой шүүлтүүр"
 
+#: modules/filter/po-filter.info:7
+#, fuzzy
+#| msgid "filter for dealing with HTML documents"
+msgid "filter to deal with gettext .po files"
+msgstr "HTML баримтуудтай холбоотой шүүлтүүр"
+
+#: modules/filter/po-filter.info:13
+msgid "review only msgids"
+msgstr ""
+
 #: modules/filter/sgml-filter.info:9
 msgid "filter for dealing with generic SGML/XML documents"
 msgstr "ерөнхий SGML/XML баримтуудтай холбоотой шүүлтүүр"
@@ -1429,6 +1435,12 @@ msgstr "HTML баримтуудыг алгасах горим"
 #| msgid "mode for checking perl comments and string literals"
 msgid "mode for checking Perl comments and string literals"
 msgstr "perl тайлбар ба стринг литериалуудыг шалгах горим"
+
+#: modules/filter/modes/po.amf:7
+#, fuzzy
+#| msgid "mode for checking HTML documents"
+msgid "mode for checking gettext .po files"
+msgstr "HTML баримтуудыг алгасах горим"
 
 #: modules/filter/modes/sgml.amf:8
 msgid "mode for checking generic SGML/XML documents"

--- a/po/ms.po
+++ b/po/ms.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aspell-0.60.6\n"
 "Report-Msgid-Bugs-To: kevina@gnu.org\n"
-"POT-Creation-Date: 2023-12-19 16:19-0500\n"
+"POT-Creation-Date: 2025-06-16 20:23-0500\n"
 "PO-Revision-Date: 2009-07-05 20:27+0800\n"
 "Last-Translator: Muhammad Najmi Ahmad Zabidi <najmi.zabidi@gmail.com>\n"
 "Language-Team: Malay <translation-team-ms@lists.sourceforge.net>\n"
@@ -450,7 +450,6 @@ msgid "The key \"%key:1\" does not take any parameters when prefixed by a \"clea
 msgstr ""
 
 #: common/errors.cpp:235
-#, c-format
 msgid "The language \"%lang:1\" is not known."
 msgstr ""
 
@@ -460,17 +459,14 @@ msgid "The soundslike \"%sl:2\" is not known."
 msgstr ""
 
 #: common/errors.cpp:251
-#, c-format
 msgid "The language \"%lang:1\" is not supported."
 msgstr ""
 
 #: common/errors.cpp:259
-#, c-format
 msgid "No word lists can be found for the language \"%lang:1\"."
 msgstr ""
 
 #: common/errors.cpp:267
-#, c-format
 msgid "Expected language \"%lang:1\" but got \"%prev:2\"."
 msgstr ""
 
@@ -1272,6 +1268,14 @@ msgstr ""
 msgid "filter for dealing with Nroff documents"
 msgstr ""
 
+#: modules/filter/po-filter.info:7
+msgid "filter to deal with gettext .po files"
+msgstr ""
+
+#: modules/filter/po-filter.info:13
+msgid "review only msgids"
+msgstr ""
+
 #: modules/filter/sgml-filter.info:9
 msgid "filter for dealing with generic SGML/XML documents"
 msgstr ""
@@ -1342,6 +1346,10 @@ msgstr ""
 
 #: modules/filter/modes/perl.amf:8
 msgid "mode for checking Perl comments and string literals"
+msgstr ""
+
+#: modules/filter/modes/po.amf:7
+msgid "mode for checking gettext .po files"
 msgstr ""
 
 #: modules/filter/modes/sgml.amf:8

--- a/po/nl.po
+++ b/po/nl.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aspell-0.60.8.1\n"
 "Report-Msgid-Bugs-To: kevina@gnu.org\n"
-"POT-Creation-Date: 2023-12-03 01:21-0500\n"
+"POT-Creation-Date: 2025-06-16 20:23-0500\n"
 "PO-Revision-Date: 2023-12-04 16:18+0100\n"
 "Last-Translator: Benno Schulenberg <vertaling@coevern.nl>\n"
 "Language-Team: Dutch <vertaling@vrijschrift.org>\n"
@@ -450,7 +450,6 @@ msgid "The key \"%key:1\" does not take any parameters when prefixed by a \"clea
 msgstr "Sleutel \"%key:1\" neemt geen parameters als deze begint met \"clear-\"."
 
 #: common/errors.cpp:235
-#, c-format
 msgid "The language \"%lang:1\" is not known."
 msgstr "Taal \"%lang:1\" is onbekend."
 
@@ -460,17 +459,14 @@ msgid "The soundslike \"%sl:2\" is not known."
 msgstr "De \"klinkt-als\" \"%sl:2\" is onbekend."
 
 #: common/errors.cpp:251
-#, c-format
 msgid "The language \"%lang:1\" is not supported."
 msgstr "De taal \"%lang:1\" wordt niet ondersteund."
 
 #: common/errors.cpp:259
-#, c-format
 msgid "No word lists can be found for the language \"%lang:1\"."
 msgstr "Voor de taal \"%lang:1\" zijn geen woordenlijsten gevonden."
 
 #: common/errors.cpp:267
-#, c-format
 msgid "Expected language \"%lang:1\" but got \"%prev:2\"."
 msgstr "Taal \"%lang:1\" verwacht, maar \"%prev:2\" gekregen."
 
@@ -1299,6 +1295,16 @@ msgstr "HTML-tags die een HTML-blok starten dat eindigt met een lege regel"
 msgid "filter for dealing with Nroff documents"
 msgstr "voor behandeling van Nroff-documenten"
 
+#: modules/filter/po-filter.info:7
+#, fuzzy
+#| msgid "filter for dealing with Texinfo documents"
+msgid "filter to deal with gettext .po files"
+msgstr "voor behandeling van Texinfo-documenten"
+
+#: modules/filter/po-filter.info:13
+msgid "review only msgids"
+msgstr ""
+
 #: modules/filter/sgml-filter.info:9
 msgid "filter for dealing with generic SGML/XML documents"
 msgstr "voor behandeling van algemene SGML/XML-documenten"
@@ -1370,6 +1376,12 @@ msgstr "voor het controleren van Nroff-documenten"
 #: modules/filter/modes/perl.amf:8
 msgid "mode for checking Perl comments and string literals"
 msgstr "voor het controleren van Perl-commentaren/tekenreeksen"
+
+#: modules/filter/modes/po.amf:7
+#, fuzzy
+#| msgid "mode for checking Texinfo documents"
+msgid "mode for checking gettext .po files"
+msgstr "voor het controleren van Texinfo-documenten"
 
 #: modules/filter/modes/sgml.amf:8
 msgid "mode for checking generic SGML/XML documents"

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aspell 0.60.8.1\n"
 "Report-Msgid-Bugs-To: kevina@gnu.org\n"
-"POT-Creation-Date: 2023-12-03 01:21-0500\n"
+"POT-Creation-Date: 2025-06-16 20:23-0500\n"
 "PO-Revision-Date: 2023-12-04 20:15+0100\n"
 "Last-Translator: Jakub Bogusz <qboosh@pld-linux.org>\n"
 "Language-Team: Polish <translation-team-pl@lists.sourceforge.net>\n"
@@ -448,7 +448,6 @@ msgid "The key \"%key:1\" does not take any parameters when prefixed by a \"clea
 msgstr "Klucz \"%key:1\" nie przyjmuje parametrów, jeśli jest poprzedzony \"clear-\"."
 
 #: common/errors.cpp:235
-#, c-format
 msgid "The language \"%lang:1\" is not known."
 msgstr "Nieznany język \"%lang:1\"."
 
@@ -458,17 +457,14 @@ msgid "The soundslike \"%sl:2\" is not known."
 msgstr "Nieznane brzmienie \"%sl:2\"."
 
 #: common/errors.cpp:251
-#, c-format
 msgid "The language \"%lang:1\" is not supported."
 msgstr "Język \"%lang:1\" nie jest obsługiwany."
 
 #: common/errors.cpp:259
-#, c-format
 msgid "No word lists can be found for the language \"%lang:1\"."
 msgstr "Brak listy słów dla języka \"%lang:1\"."
 
 #: common/errors.cpp:267
-#, c-format
 msgid "Expected language \"%lang:1\" but got \"%prev:2\"."
 msgstr "Oczekiwano języka \"%lang:1\", ale znaleziono \"%prev:2\"."
 
@@ -1286,6 +1282,16 @@ msgstr "znaczniki HTML rozpoczynające blok HTML kończący się pustą linią"
 msgid "filter for dealing with Nroff documents"
 msgstr "filtr do obsługi dokumentów Nroff"
 
+#: modules/filter/po-filter.info:7
+#, fuzzy
+#| msgid "filter for dealing with Texinfo documents"
+msgid "filter to deal with gettext .po files"
+msgstr "filtr do obsługi dokumentów Texinfo"
+
+#: modules/filter/po-filter.info:13
+msgid "review only msgids"
+msgstr ""
+
 #: modules/filter/sgml-filter.info:9
 msgid "filter for dealing with generic SGML/XML documents"
 msgstr "filtr do obsługi ogólnych dokumentów SGML/XML"
@@ -1357,6 +1363,12 @@ msgstr "tryb do sprawdzania dokumentów Nroff"
 #: modules/filter/modes/perl.amf:8
 msgid "mode for checking Perl comments and string literals"
 msgstr "tryb do sprawdzania komentarzy i łańcuchów w Perlu"
+
+#: modules/filter/modes/po.amf:7
+#, fuzzy
+#| msgid "mode for checking Texinfo documents"
+msgid "mode for checking gettext .po files"
+msgstr "tryb do sprawdzania dokumentów Texinfo"
 
 #: modules/filter/modes/sgml.amf:8
 msgid "mode for checking generic SGML/XML documents"

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aspell-0.60.8-pre2\n"
 "Report-Msgid-Bugs-To: kevina@gnu.org\n"
-"POT-Creation-Date: 2023-12-19 16:19-0500\n"
+"POT-Creation-Date: 2025-06-16 20:23-0500\n"
 "PO-Revision-Date: 2019-09-25 07:25+0100\n"
 "Last-Translator: Pedro Albuquerque <palbuquerque73@gmail.com>\n"
 "Language-Team: Portuguese <translation-team-pt@lists.sourceforge.net>\n"
@@ -450,7 +450,6 @@ msgid "The key \"%key:1\" does not take any parameters when prefixed by a \"clea
 msgstr "A chave \"%key:1\" não recebe parâmetros quando prefixada com \"clear-\""
 
 #: common/errors.cpp:235
-#, c-format
 msgid "The language \"%lang:1\" is not known."
 msgstr "O idioma \"%lang:1\" não é conhecido."
 
@@ -460,17 +459,14 @@ msgid "The soundslike \"%sl:2\" is not known."
 msgstr "Soa como \"%sl:2\" não é conhecido.."
 
 #: common/errors.cpp:251
-#, c-format
 msgid "The language \"%lang:1\" is not supported."
 msgstr "O idioma \"%lang:1\" não é suportado."
 
 #: common/errors.cpp:259
-#, c-format
 msgid "No word lists can be found for the language \"%lang:1\"."
 msgstr "Não se encontraram listas de palavras para \"%lang:1\"."
 
 #: common/errors.cpp:267
-#, c-format
 msgid "Expected language \"%lang:1\" but got \"%prev:2\"."
 msgstr "Esperado idioma \"%lang:1\", obtido \"%prev:2\"."
 
@@ -1295,6 +1291,16 @@ msgstr "etiquetas HTML que iniciam um bloco HTML que termina com uma linha em br
 msgid "filter for dealing with Nroff documents"
 msgstr "filtro para lidar com documentos Nroff"
 
+#: modules/filter/po-filter.info:7
+#, fuzzy
+#| msgid "filter for dealing with Texinfo documents"
+msgid "filter to deal with gettext .po files"
+msgstr "filtro para lidar com documentos Texinfo"
+
+#: modules/filter/po-filter.info:13
+msgid "review only msgids"
+msgstr ""
+
 #: modules/filter/sgml-filter.info:9
 msgid "filter for dealing with generic SGML/XML documents"
 msgstr "filtro para lidar com documentos genéricos SGML/XML"
@@ -1366,6 +1372,12 @@ msgstr "modo para verificar documentos Nroff"
 #: modules/filter/modes/perl.amf:8
 msgid "mode for checking Perl comments and string literals"
 msgstr "modo para verificar comentários Perl e literais de cadeia"
+
+#: modules/filter/modes/po.amf:7
+#, fuzzy
+#| msgid "mode for checking Texinfo documents"
+msgid "mode for checking gettext .po files"
+msgstr "modo para verificar documentos Texinfo"
 
 #: modules/filter/modes/sgml.amf:8
 msgid "mode for checking generic SGML/XML documents"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aspell 0.60.8.1\n"
 "Report-Msgid-Bugs-To: kevina@gnu.org\n"
-"POT-Creation-Date: 2023-12-03 01:21-0500\n"
+"POT-Creation-Date: 2025-06-16 20:23-0500\n"
 "PO-Revision-Date: 2023-12-04 10:04-0300\n"
 "Last-Translator: Rafael Fontenelle <rafaelff@gnome.org>\n"
 "Language-Team: Brazilian Portuguese <ldpbr-translation@lists.sourceforge.net>\n"
@@ -452,7 +452,6 @@ msgid "The key \"%key:1\" does not take any parameters when prefixed by a \"clea
 msgstr "A chave \"%key:1\" não leva parâmetros quando prefixada por um \"clear-\"."
 
 #: common/errors.cpp:235
-#, c-format
 msgid "The language \"%lang:1\" is not known."
 msgstr "O idioma \"%lang:1\" é desconhecido."
 
@@ -462,17 +461,14 @@ msgid "The soundslike \"%sl:2\" is not known."
 msgstr "A pronúncia \"%sl:2\" é desconhecida."
 
 #: common/errors.cpp:251
-#, c-format
 msgid "The language \"%lang:1\" is not supported."
 msgstr "O idioma \"%lang:1\" não é suportado."
 
 #: common/errors.cpp:259
-#, c-format
 msgid "No word lists can be found for the language \"%lang:1\"."
 msgstr "Nenhum vocabulário foi localizado para o idioma \"%lang:1\"."
 
 #: common/errors.cpp:267
-#, c-format
 msgid "Expected language \"%lang:1\" but got \"%prev:2\"."
 msgstr "Idioma \"%lang:1\" esperado, mas \"%prev:2\" obtido."
 
@@ -1289,6 +1285,16 @@ msgstr "etiquetas HTML que iniciam um bloco HTML que termina com uma linha em br
 msgid "filter for dealing with Nroff documents"
 msgstr "filtro para manipular documentos Nroff"
 
+#: modules/filter/po-filter.info:7
+#, fuzzy
+#| msgid "filter for dealing with Texinfo documents"
+msgid "filter to deal with gettext .po files"
+msgstr "filtro para manipular documentos Texinfo"
+
+#: modules/filter/po-filter.info:13
+msgid "review only msgids"
+msgstr ""
+
 #: modules/filter/sgml-filter.info:9
 msgid "filter for dealing with generic SGML/XML documents"
 msgstr "filtro para manipular documentos SGML/XML genéricos"
@@ -1360,6 +1366,12 @@ msgstr "modo para verificar documentos Nroff"
 #: modules/filter/modes/perl.amf:8
 msgid "mode for checking Perl comments and string literals"
 msgstr "modo para verificar comentários Perl e strings literais"
+
+#: modules/filter/modes/po.amf:7
+#, fuzzy
+#| msgid "mode for checking Texinfo documents"
+msgid "mode for checking gettext .po files"
+msgstr "modo para verificar documentos Texinfo"
 
 #: modules/filter/modes/sgml.amf:8
 msgid "mode for checking generic SGML/XML documents"

--- a/po/ro.po
+++ b/po/ro.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aspell 0.60.8.1\n"
 "Report-Msgid-Bugs-To: kevina@gnu.org\n"
-"POT-Creation-Date: 2023-12-03 01:21-0500\n"
+"POT-Creation-Date: 2025-06-16 20:23-0500\n"
 "PO-Revision-Date: 2023-12-04 11:54+0100\n"
 "Last-Translator: Remus-Gabriel Chelu <remusgabriel.chelu@disroot.org>\n"
 "Language-Team: Romanian <translation-team-ro@lists.sourceforge.net>\n"
@@ -477,7 +477,6 @@ msgid "The key \"%key:1\" does not take any parameters when prefixed by a \"clea
 msgstr "Cheia „%key:1” nu ia nici un parametru când este prefixată de un „clear-”."
 
 #: common/errors.cpp:235
-#, c-format
 msgid "The language \"%lang:1\" is not known."
 msgstr "Limba „%lang:1” nu este cunoscută."
 
@@ -487,17 +486,14 @@ msgid "The soundslike \"%sl:2\" is not known."
 msgstr "Sună-ca „%sl:2” nu este cunoscut."
 
 #: common/errors.cpp:251
-#, c-format
 msgid "The language \"%lang:1\" is not supported."
 msgstr "Limba „%lang:1” nu este admisă."
 
 #: common/errors.cpp:259
-#, c-format
 msgid "No word lists can be found for the language \"%lang:1\"."
 msgstr "Nu poate fi găsită nici o listă de cuvinte pentru limba „%lang:1”."
 
 #: common/errors.cpp:267
-#, c-format
 msgid "Expected language \"%lang:1\" but got \"%prev:2\"."
 msgstr "Se aștepta limba „%lang:1” dar s-a primit limba „%prev:2”."
 
@@ -1320,6 +1316,16 @@ msgstr "Marcaje HTML care încep un bloc HTML care se termină cu o linie goală
 msgid "filter for dealing with Nroff documents"
 msgstr "filtru pentru procesarea documentelor Nroff"
 
+#: modules/filter/po-filter.info:7
+#, fuzzy
+#| msgid "filter for dealing with Texinfo documents"
+msgid "filter to deal with gettext .po files"
+msgstr "filtru pentru procesarea documentelor Texinfo"
+
+#: modules/filter/po-filter.info:13
+msgid "review only msgids"
+msgstr ""
+
 #: modules/filter/sgml-filter.info:9
 msgid "filter for dealing with generic SGML/XML documents"
 msgstr "filtru pentru procesarea documentelor SGML/XML generice"
@@ -1391,6 +1397,12 @@ msgstr "mod pentru verificarea documentelor Nroff"
 #: modules/filter/modes/perl.amf:8
 msgid "mode for checking Perl comments and string literals"
 msgstr "mod pentru verificarea comentariilor Perl și a șirurilor literare"
+
+#: modules/filter/modes/po.amf:7
+#, fuzzy
+#| msgid "mode for checking Texinfo documents"
+msgid "mode for checking gettext .po files"
+msgstr "mod pentru verificarea documentelor Texinfo"
 
 #: modules/filter/modes/sgml.amf:8
 msgid "mode for checking generic SGML/XML documents"

--- a/po/ru.po
+++ b/po/ru.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aspell-0.60.8-pre2\n"
 "Report-Msgid-Bugs-To: kevina@gnu.org\n"
-"POT-Creation-Date: 2023-12-19 16:19-0500\n"
+"POT-Creation-Date: 2025-06-16 20:23-0500\n"
 "PO-Revision-Date: 2019-09-24 18:53+0300\n"
 "Last-Translator: Yuri Kozlov <yuray@komyakino.ru>\n"
 "Language-Team: Russian <gnu@d07.ru>\n"
@@ -452,7 +452,6 @@ msgid "The key \"%key:1\" does not take any parameters when prefixed by a \"clea
 msgstr "Ключ \"%key:1\" не допускает никаких параметров с префиксом \"clear-\"."
 
 #: common/errors.cpp:235
-#, c-format
 msgid "The language \"%lang:1\" is not known."
 msgstr "Язык \"%lang:1\" не известен."
 
@@ -462,17 +461,14 @@ msgid "The soundslike \"%sl:2\" is not known."
 msgstr "Soundslike \"%sl:2\" не известен."
 
 #: common/errors.cpp:251
-#, c-format
 msgid "The language \"%lang:1\" is not supported."
 msgstr "Язык \"%lang:1\" не поддерживается."
 
 #: common/errors.cpp:259
-#, c-format
 msgid "No word lists can be found for the language \"%lang:1\"."
 msgstr "Списки слов не могут быть найдены для языка \"%lang:1\"."
 
 #: common/errors.cpp:267
-#, c-format
 msgid "Expected language \"%lang:1\" but got \"%prev:2\"."
 msgstr "Ожидался язык \"%lang:1\", а получен \"%prev:2\"."
 
@@ -1298,6 +1294,16 @@ msgstr "теги HTML, начинающие блок HTML, который зак
 msgid "filter for dealing with Nroff documents"
 msgstr "фильтр для работы с документами Nroff"
 
+#: modules/filter/po-filter.info:7
+#, fuzzy
+#| msgid "filter for dealing with Texinfo documents"
+msgid "filter to deal with gettext .po files"
+msgstr "фильтр для работы с документами Texinfo"
+
+#: modules/filter/po-filter.info:13
+msgid "review only msgids"
+msgstr ""
+
 #: modules/filter/sgml-filter.info:9
 msgid "filter for dealing with generic SGML/XML documents"
 msgstr "фильтр для работы с обычными документами SGML/XML"
@@ -1369,6 +1375,12 @@ msgstr "режим проверки документов Nroff"
 #: modules/filter/modes/perl.amf:8
 msgid "mode for checking Perl comments and string literals"
 msgstr "режим проверки комментариев Perl и строковых литералов"
+
+#: modules/filter/modes/po.amf:7
+#, fuzzy
+#| msgid "mode for checking Texinfo documents"
+msgid "mode for checking gettext .po files"
+msgstr "режим проверки документов Texinfo"
 
 #: modules/filter/modes/sgml.amf:8
 msgid "mode for checking generic SGML/XML documents"

--- a/po/rw.po
+++ b/po/rw.po
@@ -16,7 +16,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aspell 0.60\n"
 "Report-Msgid-Bugs-To: kevina@gnu.org\n"
-"POT-Creation-Date: 2023-12-19 16:19-0500\n"
+"POT-Creation-Date: 2025-06-16 20:23-0500\n"
 "PO-Revision-Date: 2005-04-04 10:55-0700\n"
 "Last-Translator: Steven Michael Murphy <murf@e-tools.com>\n"
 "Language-Team: Kinyarwanda <translation-team-rw@lists.sourceforge.net>\n"
@@ -538,7 +538,7 @@ msgid "The key \"%key:1\" does not take any parameters when prefixed by a \"clea
 msgstr "Urufunguzo 1. OYA Ibigenga Ryari: ku a Gusiba"
 
 #: common/errors.cpp:235
-#, fuzzy, c-format
+#, fuzzy
 msgid "The language \"%lang:1\" is not known."
 msgstr "Ururimi 1. ni OYA"
 
@@ -548,17 +548,17 @@ msgid "The soundslike \"%sl:2\" is not known."
 msgstr "2. ni OYA"
 
 #: common/errors.cpp:251
-#, fuzzy, c-format
+#, fuzzy
 msgid "The language \"%lang:1\" is not supported."
 msgstr "Ururimi 1. ni OYA"
 
 #: common/errors.cpp:259
-#, fuzzy, c-format
+#, fuzzy
 msgid "No word lists can be found for the language \"%lang:1\"."
 msgstr "ijambo Intonde Byabonetse kugirango i Ururimi 1."
 
 #: common/errors.cpp:267
-#, fuzzy, c-format
+#, fuzzy
 msgid "Expected language \"%lang:1\" but got \"%prev:2\"."
 msgstr "Itegerejwe Ururimi 1. 2."
 
@@ -1473,6 +1473,15 @@ msgstr ""
 msgid "filter for dealing with Nroff documents"
 msgstr "Muyunguruzi... kugirango Na: Inyandiko"
 
+#: modules/filter/po-filter.info:7
+#, fuzzy
+msgid "filter to deal with gettext .po files"
+msgstr "Muyunguruzi... kugirango Na: Inyandiko"
+
+#: modules/filter/po-filter.info:13
+msgid "review only msgids"
+msgstr ""
+
 #: modules/filter/sgml-filter.info:9
 #, fuzzy
 msgid "filter for dealing with generic SGML/XML documents"
@@ -1561,6 +1570,11 @@ msgstr "Ubwoko kugirango Inyandiko"
 #, fuzzy
 msgid "mode for checking Perl comments and string literals"
 msgstr "Ubwoko kugirango Ibisobanuro Na Ikurikiranyanyuguti"
+
+#: modules/filter/modes/po.amf:7
+#, fuzzy
+msgid "mode for checking gettext .po files"
+msgstr "Ubwoko kugirango Inyandiko"
 
 #: modules/filter/modes/sgml.amf:8
 #, fuzzy

--- a/po/sk.po
+++ b/po/sk.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aspell 0.60.7\n"
 "Report-Msgid-Bugs-To: kevina@gnu.org\n"
-"POT-Creation-Date: 2023-12-19 16:19-0500\n"
+"POT-Creation-Date: 2025-06-16 20:23-0500\n"
 "PO-Revision-Date: 2011-07-08 20:53+0100\n"
 "Last-Translator: Ivan Masár <helix84@centrum.sk>\n"
 "Language-Team: Slovak <sk-i18n@lists.linux.sk>\n"
@@ -455,7 +455,6 @@ msgid "The key \"%key:1\" does not take any parameters when prefixed by a \"clea
 msgstr "Kľúč \"%key:1\" neprijíma parametre keď mu predchádza \"clear-\"."
 
 #: common/errors.cpp:235
-#, c-format
 msgid "The language \"%lang:1\" is not known."
 msgstr "Jazyk \"%lang:1\" nie je známy."
 
@@ -465,17 +464,14 @@ msgid "The soundslike \"%sl:2\" is not known."
 msgstr "Homonymum \"%sl:2\" nie je známe."
 
 #: common/errors.cpp:251
-#, c-format
 msgid "The language \"%lang:1\" is not supported."
 msgstr "Jazyk \"%lang:1\" nie je podporovaný."
 
 #: common/errors.cpp:259
-#, c-format
 msgid "No word lists can be found for the language \"%lang:1\"."
 msgstr "Pre jazyk \"%lang:1\" neboli nájdené žiadne zoznamy slov."
 
 #: common/errors.cpp:267
-#, c-format
 msgid "Expected language \"%lang:1\" but got \"%prev:2\"."
 msgstr "Očakáaný jazyk bol \"%lang:1\", ale dostal som \"%prev:2\"."
 
@@ -1305,6 +1301,16 @@ msgstr ""
 msgid "filter for dealing with Nroff documents"
 msgstr "filter pre zaobchádzanie s dokumentami Nroff"
 
+#: modules/filter/po-filter.info:7
+#, fuzzy
+#| msgid "filter for dealing with Texinfo documents"
+msgid "filter to deal with gettext .po files"
+msgstr "filter pre zaobchádzanie s dokumentami Texinfo"
+
+#: modules/filter/po-filter.info:13
+msgid "review only msgids"
+msgstr ""
+
 #: modules/filter/sgml-filter.info:9
 msgid "filter for dealing with generic SGML/XML documents"
 msgstr "filter pre zaobchádzanie so všeobecnými dokumentami SGML/XML"
@@ -1378,6 +1384,12 @@ msgstr "režim kontroly dokumentov Nroff"
 #: modules/filter/modes/perl.amf:8
 msgid "mode for checking Perl comments and string literals"
 msgstr "režim kontroly komentárov a reťazcových literálov Perl"
+
+#: modules/filter/modes/po.amf:7
+#, fuzzy
+#| msgid "mode for checking Texinfo documents"
+msgid "mode for checking gettext .po files"
+msgstr "režim kontroly dokumentov Texinfo"
 
 #: modules/filter/modes/sgml.amf:8
 msgid "mode for checking generic SGML/XML documents"

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aspell 0.60.8-pre2\n"
 "Report-Msgid-Bugs-To: kevina@gnu.org\n"
-"POT-Creation-Date: 2023-12-19 16:19-0500\n"
+"POT-Creation-Date: 2025-06-16 20:23-0500\n"
 "PO-Revision-Date: 2019-09-24 17:15+0200\n"
 "Last-Translator: Martin Srebotnjak <miles@filmsi.net>\n"
 "Language-Team: Slovenian <translation-team-sl@lists.sourceforge.net>\n"
@@ -451,7 +451,6 @@ msgid "The key \"%key:1\" does not take any parameters when prefixed by a \"clea
 msgstr "Ključ \"%key:1\" ne sprejema parametrov, ki imajo predpono \"clear-\"."
 
 #: common/errors.cpp:235
-#, c-format
 msgid "The language \"%lang:1\" is not known."
 msgstr "Jezik \"%lang:1\" ni poznan."
 
@@ -461,17 +460,14 @@ msgid "The soundslike \"%sl:2\" is not known."
 msgstr "Zveni-kot \"%sl:2\" ni poznan."
 
 #: common/errors.cpp:251
-#, c-format
 msgid "The language \"%lang:1\" is not supported."
 msgstr "Jezik \"%lang:1\" ni podprt."
 
 #: common/errors.cpp:259
-#, c-format
 msgid "No word lists can be found for the language \"%lang:1\"."
 msgstr "Za jezik \"%lang:1\" ni seznamov besed."
 
 #: common/errors.cpp:267
-#, c-format
 msgid "Expected language \"%lang:1\" but got \"%prev:2\"."
 msgstr "Pričakovani jezik je bil \"%lang:1\", vendar se je pojavila \"%prev:2\"."
 
@@ -1294,6 +1290,16 @@ msgstr "oznake HTML, ki začenjajo blok HTML, ki se konča s prazno vrstico"
 msgid "filter for dealing with Nroff documents"
 msgstr "filter za obravnavo dokumentov Nroff"
 
+#: modules/filter/po-filter.info:7
+#, fuzzy
+#| msgid "filter for dealing with Texinfo documents"
+msgid "filter to deal with gettext .po files"
+msgstr "filter za obravnavo dokumentov Texinfo"
+
+#: modules/filter/po-filter.info:13
+msgid "review only msgids"
+msgstr ""
+
 #: modules/filter/sgml-filter.info:9
 msgid "filter for dealing with generic SGML/XML documents"
 msgstr "filter za obravnavo splošnih dokumentov SGML/XML"
@@ -1365,6 +1371,12 @@ msgstr "način preverjanja dokumentov Nroff"
 #: modules/filter/modes/perl.amf:8
 msgid "mode for checking Perl comments and string literals"
 msgstr "način preverjanja komentarjev Perl in dobesednih nizov"
+
+#: modules/filter/modes/po.amf:7
+#, fuzzy
+#| msgid "mode for checking Texinfo documents"
+msgid "mode for checking gettext .po files"
+msgstr "način preverjanja dokumentov Texinfo"
 
 #: modules/filter/modes/sgml.amf:8
 msgid "mode for checking generic SGML/XML documents"

--- a/po/sq.po
+++ b/po/sq.po
@@ -7,15 +7,15 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aspell 0.60.8-pre2\n"
 "Report-Msgid-Bugs-To: kevina@gnu.org\n"
-"POT-Creation-Date: 2019-09-24 03:02-0400\n"
+"POT-Creation-Date: 2025-06-16 20:23-0500\n"
 "PO-Revision-Date: 2020-04-01 13:40+0300\n"
 "Last-Translator: Besnik Bleta <besnik@programeshqip.org>\n"
 "Language-Team: Albanian <translation-team-sq@lists.sourceforge.net>\n"
 "Language: sq\n"
-"X-Bugs: Report translation errors to the Language-Team address.\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"X-Bugs: Report translation errors to the Language-Team address.\n"
 "X-Generator: Poedit 2.2\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
@@ -450,7 +450,6 @@ msgid "The key \"%key:1\" does not take any parameters when prefixed by a \"clea
 msgstr ""
 
 #: common/errors.cpp:235
-#, c-format
 msgid "The language \"%lang:1\" is not known."
 msgstr "Gjuha \"%lang:1\" është e panjohur."
 
@@ -460,17 +459,14 @@ msgid "The soundslike \"%sl:2\" is not known."
 msgstr "\"Soundslike\" \"%sl:2\" është i panjohur."
 
 #: common/errors.cpp:251
-#, c-format
 msgid "The language \"%lang:1\" is not supported."
 msgstr "Gjuha \"%lang:1\" nuk mbulohet."
 
 #: common/errors.cpp:259
-#, c-format
 msgid "No word lists can be found for the language \"%lang:1\"."
 msgstr "S’gjenden lista fjalësh për gjuhën \"%lang:1\"."
 
 #: common/errors.cpp:267
-#, c-format
 msgid "Expected language \"%lang:1\" but got \"%prev:2\"."
 msgstr "Pritej gjuha \"%lang:1\", por u mor \"%prev:2\"."
 
@@ -681,7 +677,9 @@ msgid "Invalid Option: %s"
 msgstr "Mundësi e Pavlefshme: %s"
 
 #: prog/aspell.cpp:322
-msgid " does not take any parameters."
+#, fuzzy, c-format
+#| msgid " does not take any parameters."
+msgid "'%s' does not take any parameters."
 msgstr " nuk merr ndonjë parametër."
 
 #: prog/aspell.cpp:335 prog/aspell.cpp:395
@@ -934,10 +932,14 @@ msgid "  <norm-form>      normalization form to use, either none, internal, or s
 msgstr "  <norm-form>      formë normalizimi për t’u përdorur, një nga \"none\", \"internal\", ose \"strict\""
 
 #: prog/aspell.cpp:2884
-#, c-format
+#, fuzzy, c-format
+#| msgid ""
+#| "\n"
+#| "Aspell %s.  Copyright 2000-2019 by Kevin Atkinson.\n"
+#| "\n"
 msgid ""
 "\n"
-"Aspell %s.  Copyright 2000-2019 by Kevin Atkinson.\n"
+"Aspell %s.  Copyright 2000-2023 by Kevin Atkinson.\n"
 "\n"
 msgstr ""
 "\n"
@@ -1201,7 +1203,7 @@ msgstr "Gjatësia në tërësi e fjalës, me të dhënat \"soundslike\", është
 msgid "There must be at least one \"add\" line."
 msgstr "Duhet të ketë të paktën një rresht \"add\"."
 
-#: modules/speller/default/suggest.cpp:1720
+#: modules/speller/default/suggest.cpp:1730
 msgid "one of ultra, fast, normal, slow, or bad-spellers"
 msgstr "një nga ultra, fast, normal, slow, ose bad-spellers"
 
@@ -1288,6 +1290,16 @@ msgstr "Etiketa HTML që nisin një bllok HTML i cili përfundon me një rresht 
 msgid "filter for dealing with Nroff documents"
 msgstr "filtër për trajtim dokumentesh Nroff"
 
+#: modules/filter/po-filter.info:7
+#, fuzzy
+#| msgid "filter for dealing with Texinfo documents"
+msgid "filter to deal with gettext .po files"
+msgstr "filtër për trajtim dokumentesh Texinfo"
+
+#: modules/filter/po-filter.info:13
+msgid "review only msgids"
+msgstr ""
+
 #: modules/filter/sgml-filter.info:9
 msgid "filter for dealing with generic SGML/XML documents"
 msgstr "filtër për trajtim dokumentesh të thjeshtë SGML/XML"
@@ -1359,6 +1371,12 @@ msgstr "mënyrë për kontroll dokumentesh Nroff"
 #: modules/filter/modes/perl.amf:8
 msgid "mode for checking Perl comments and string literals"
 msgstr ""
+
+#: modules/filter/modes/po.amf:7
+#, fuzzy
+#| msgid "mode for checking Texinfo documents"
+msgid "mode for checking gettext .po files"
+msgstr "mënyrë për kontroll dokumentesh Texinfo"
 
 #: modules/filter/modes/sgml.amf:8
 msgid "mode for checking generic SGML/XML documents"

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aspell-0.60.8-pre2\n"
 "Report-Msgid-Bugs-To: kevina@gnu.org\n"
-"POT-Creation-Date: 2019-09-24 03:02-0400\n"
+"POT-Creation-Date: 2025-06-16 20:23-0500\n"
 "PO-Revision-Date: 2020-03-31 13:52+0200\n"
 "Last-Translator: Мирослав Николић <miroslavnikolic@rocketmail.com>\n"
 "Language-Team: Serbian <(nothing)>\n"
@@ -453,7 +453,6 @@ msgid "The key \"%key:1\" does not take any parameters when prefixed by a \"clea
 msgstr "Кључ „%key:1“ не узима параметре ако му се дода „clear-“."
 
 #: common/errors.cpp:235
-#, c-format
 msgid "The language \"%lang:1\" is not known."
 msgstr "Језик „%lang:1“ није познат."
 
@@ -463,17 +462,14 @@ msgid "The soundslike \"%sl:2\" is not known."
 msgstr "Звучикао „%sl:2“ није познат."
 
 #: common/errors.cpp:251
-#, c-format
 msgid "The language \"%lang:1\" is not supported."
 msgstr "Језик „%lang:1“ није подржан."
 
 #: common/errors.cpp:259
-#, c-format
 msgid "No word lists can be found for the language \"%lang:1\"."
 msgstr "Не могу се наћи спискови речи за језик „%lang:1“."
 
 #: common/errors.cpp:267
-#, c-format
 msgid "Expected language \"%lang:1\" but got \"%prev:2\"."
 msgstr "Очекивах језик „%lang:1“ али примих „%prev:2“."
 
@@ -685,7 +681,9 @@ msgid "Invalid Option: %s"
 msgstr "Неисправна опција: %s"
 
 #: prog/aspell.cpp:322
-msgid " does not take any parameters."
+#, fuzzy, c-format
+#| msgid " does not take any parameters."
+msgid "'%s' does not take any parameters."
 msgstr " не прихвата никакве параметре."
 
 #: prog/aspell.cpp:335 prog/aspell.cpp:395
@@ -940,10 +938,14 @@ msgid "  <norm-form>      normalization form to use, either none, internal, or s
 msgstr "  <облик-правила>        облик сређивања за коришћење, „none“, „internal“, или „strict“"
 
 #: prog/aspell.cpp:2884
-#, c-format
+#, fuzzy, c-format
+#| msgid ""
+#| "\n"
+#| "Aspell %s.  Copyright 2000-2019 by Kevin Atkinson.\n"
+#| "\n"
 msgid ""
 "\n"
-"Aspell %s.  Copyright 2000-2019 by Kevin Atkinson.\n"
+"Aspell %s.  Copyright 2000-2023 by Kevin Atkinson.\n"
 "\n"
 msgstr ""
 "\n"
@@ -1208,7 +1210,7 @@ msgstr "Укупна дужина речи, са подацима звучика
 msgid "There must be at least one \"add\" line."
 msgstr "Мора да постоји барем један „add“ ред."
 
-#: modules/speller/default/suggest.cpp:1720
+#: modules/speller/default/suggest.cpp:1730
 msgid "one of ultra, fast, normal, slow, or bad-spellers"
 msgstr "један од ultra, fast, normal, slow, или bad-spellers"
 
@@ -1295,6 +1297,16 @@ msgstr "ХТМЛ ознаке које покрећу ХТМЛ блок који
 msgid "filter for dealing with Nroff documents"
 msgstr "филтер за поступање са Бриск документима"
 
+#: modules/filter/po-filter.info:7
+#, fuzzy
+#| msgid "filter for dealing with Texinfo documents"
+msgid "filter to deal with gettext .po files"
+msgstr "филтер за поступање са Тексинфо документима"
+
+#: modules/filter/po-filter.info:13
+msgid "review only msgids"
+msgstr ""
+
 #: modules/filter/sgml-filter.info:9
 msgid "filter for dealing with generic SGML/XML documents"
 msgstr "филтер за поступање са општим СГМЛ/ХМЛ документима"
@@ -1366,6 +1378,12 @@ msgstr "режим за проверу Бриск докумената"
 #: modules/filter/modes/perl.amf:8
 msgid "mode for checking Perl comments and string literals"
 msgstr "режим за проверу Перл примедби и дословности ниске"
+
+#: modules/filter/modes/po.amf:7
+#, fuzzy
+#| msgid "mode for checking Texinfo documents"
+msgid "mode for checking gettext .po files"
+msgstr "режим за проверу Тексинфо докумената"
 
 #: modules/filter/modes/sgml.amf:8
 msgid "mode for checking generic SGML/XML documents"

--- a/po/sv.po
+++ b/po/sv.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aspell 0.60.8-pre2\n"
 "Report-Msgid-Bugs-To: kevina@gnu.org\n"
-"POT-Creation-Date: 2019-09-24 03:02-0400\n"
+"POT-Creation-Date: 2025-06-16 20:23-0500\n"
 "PO-Revision-Date: 2020-05-16 21:22+0200\n"
 "Last-Translator: Josef Andersson <l10nl18nsweja@gmail.com>\n"
 "Language-Team: Swedish <tp-sv-list@lists.sourceforge.net>\n"
@@ -453,7 +453,6 @@ msgid "The key \"%key:1\" does not take any parameters when prefixed by a \"clea
 msgstr "Nyckeln ”%key:1” tar inga parametrar när den föregås av ”clear-”."
 
 #: common/errors.cpp:235
-#, c-format
 msgid "The language \"%lang:1\" is not known."
 msgstr "Språket ”%lang:1” är inte känt."
 
@@ -463,17 +462,14 @@ msgid "The soundslike \"%sl:2\" is not known."
 msgstr "Soundslike ”%sl:2” är okänd."
 
 #: common/errors.cpp:251
-#, c-format
 msgid "The language \"%lang:1\" is not supported."
 msgstr "Språket ”%lang:1” stöds inte."
 
 #: common/errors.cpp:259
-#, c-format
 msgid "No word lists can be found for the language \"%lang:1\"."
 msgstr "Inga ordlistor kan hittas för språket ”%lang:1”."
 
 #: common/errors.cpp:267
-#, c-format
 msgid "Expected language \"%lang:1\" but got \"%prev:2\"."
 msgstr "Förväntade språket ”%lang:1” men fick ”%prev:2”."
 
@@ -684,7 +680,9 @@ msgid "Invalid Option: %s"
 msgstr "Ogiltig flagga: %s"
 
 #: prog/aspell.cpp:322
-msgid " does not take any parameters."
+#, fuzzy, c-format
+#| msgid " does not take any parameters."
+msgid "'%s' does not take any parameters."
 msgstr " tar inga parametrar."
 
 #: prog/aspell.cpp:335 prog/aspell.cpp:395
@@ -937,10 +935,14 @@ msgid "  <norm-form>      normalization form to use, either none, internal, or s
 msgstr "  <norm-form>      normaliseringsform att använda; antingen none, internal, eller strict"
 
 #: prog/aspell.cpp:2884
-#, c-format
+#, fuzzy, c-format
+#| msgid ""
+#| "\n"
+#| "Aspell %s.  Copyright 2000-2019 by Kevin Atkinson.\n"
+#| "\n"
 msgid ""
 "\n"
-"Aspell %s.  Copyright 2000-2019 by Kevin Atkinson.\n"
+"Aspell %s.  Copyright 2000-2023 by Kevin Atkinson.\n"
 "\n"
 msgstr ""
 "\n"
@@ -1202,7 +1204,7 @@ msgstr "Total ordlängd, med soundslike-data, överstiger 240 tecken."
 msgid "There must be at least one \"add\" line."
 msgstr "Det måste finnas minst en ”add”-rad."
 
-#: modules/speller/default/suggest.cpp:1720
+#: modules/speller/default/suggest.cpp:1730
 msgid "one of ultra, fast, normal, slow, or bad-spellers"
 msgstr "antingen ultra, fast, normal, slow, eller bad-spellers"
 
@@ -1289,6 +1291,16 @@ msgstr "HTML-taggar som påbörjar ett HTML-block vilket slutar med en blankrad"
 msgid "filter for dealing with Nroff documents"
 msgstr "filter för hantering av Nroff-dokument"
 
+#: modules/filter/po-filter.info:7
+#, fuzzy
+#| msgid "filter for dealing with Texinfo documents"
+msgid "filter to deal with gettext .po files"
+msgstr "filter för hantering av Texinfo-dokument"
+
+#: modules/filter/po-filter.info:13
+msgid "review only msgids"
+msgstr ""
+
 #: modules/filter/sgml-filter.info:9
 msgid "filter for dealing with generic SGML/XML documents"
 msgstr "filter för hantering av vanl. SGML-/XML-dokument"
@@ -1360,6 +1372,12 @@ msgstr "läge för att kontrollera Nroff-dokument"
 #: modules/filter/modes/perl.amf:8
 msgid "mode for checking Perl comments and string literals"
 msgstr "läge för att kontrollera Perl-kommentarer och strängstavningar"
+
+#: modules/filter/modes/po.amf:7
+#, fuzzy
+#| msgid "mode for checking Texinfo documents"
+msgid "mode for checking gettext .po files"
+msgstr "läge för att kontrollera Texinfo-dokument"
 
 #: modules/filter/modes/sgml.amf:8
 msgid "mode for checking generic SGML/XML documents"

--- a/po/tg.po
+++ b/po/tg.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aspell\n"
 "Report-Msgid-Bugs-To: kevina@gnu.org\n"
-"POT-Creation-Date: 2023-12-19 16:19-0500\n"
+"POT-Creation-Date: 2025-06-16 20:23-0500\n"
 "PO-Revision-Date: 2004-05-22 19:33+0000\n"
 "Last-Translator: Marina Kolucheva <youth_opportunities@tajik.net>\n"
 "Language-Team: Tajik\n"
@@ -470,7 +470,6 @@ msgid "The key \"%key:1\" does not take any parameters when prefixed by a \"clea
 msgstr ""
 
 #: common/errors.cpp:235
-#, c-format
 msgid "The language \"%lang:1\" is not known."
 msgstr "Забони \"%lang:1\" номуайян аст."
 
@@ -480,17 +479,14 @@ msgid "The soundslike \"%sl:2\" is not known."
 msgstr "Soundslike \"%sl:2\" номуайян аст."
 
 #: common/errors.cpp:251
-#, c-format
 msgid "The language \"%lang:1\" is not supported."
 msgstr "Забони \"%lang:1\" дастгирӣ нашуда истодааст."
 
 #: common/errors.cpp:259
-#, c-format
 msgid "No word lists can be found for the language \"%lang:1\"."
 msgstr "Рӯйхати калимаҳо барои забони \"%lang:1\" ёфт нашуда истодаанд."
 
 #: common/errors.cpp:267
-#, c-format
 msgid "Expected language \"%lang:1\" but got \"%prev:2\"."
 msgstr "Интизори забони \"%lang:1\"буд ва лекин \"%prev:2\" қабул шуд."
 
@@ -1321,6 +1317,15 @@ msgstr ""
 msgid "filter for dealing with Nroff documents"
 msgstr "филтр барои дарёфти фармоноти TeX/LaTeX"
 
+#: modules/filter/po-filter.info:7
+#, fuzzy
+msgid "filter to deal with gettext .po files"
+msgstr "филтр барои дарёфти фармоноти TeX/LaTeX"
+
+#: modules/filter/po-filter.info:13
+msgid "review only msgids"
+msgstr ""
+
 #: modules/filter/sgml-filter.info:9
 msgid "filter for dealing with generic SGML/XML documents"
 msgstr ""
@@ -1401,6 +1406,11 @@ msgstr "филтр барои дарёфти фармоноти TeX/LaTeX"
 #: modules/filter/modes/perl.amf:8
 #, fuzzy
 msgid "mode for checking Perl comments and string literals"
+msgstr "филтр барои дарёфти фармоноти TeX/LaTeX"
+
+#: modules/filter/modes/po.amf:7
+#, fuzzy
+msgid "mode for checking gettext .po files"
 msgstr "филтр барои дарёфти фармоноти TeX/LaTeX"
 
 #: modules/filter/modes/sgml.amf:8

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aspell 0.60.8.1\n"
 "Report-Msgid-Bugs-To: kevina@gnu.org\n"
-"POT-Creation-Date: 2023-12-03 01:21-0500\n"
+"POT-Creation-Date: 2025-06-16 20:23-0500\n"
 "PO-Revision-Date: 2023-12-04 17:09+0200\n"
 "Last-Translator: Yuri Chornoivan <yurchor@ukr.net>\n"
 "Language-Team: Ukrainian <trans-uk@lists.fedoraproject.org>\n"
@@ -452,7 +452,6 @@ msgid "The key \"%key:1\" does not take any parameters when prefixed by a \"clea
 msgstr "Ключ \"%key:1\" не допускає ніяких параметрів з префіксом \"clear-\"."
 
 #: common/errors.cpp:235
-#, c-format
 msgid "The language \"%lang:1\" is not known."
 msgstr "Невідома мова \"%lang:1\"."
 
@@ -462,17 +461,14 @@ msgid "The soundslike \"%sl:2\" is not known."
 msgstr "Невідомий soundslike \"%sl:2\"."
 
 #: common/errors.cpp:251
-#, c-format
 msgid "The language \"%lang:1\" is not supported."
 msgstr "Мова \"%lang:1\" не підтримується."
 
 #: common/errors.cpp:259
-#, c-format
 msgid "No word lists can be found for the language \"%lang:1\"."
 msgstr "Не вдається знайти списки слів для мови \"%lang:1\"."
 
 #: common/errors.cpp:267
-#, c-format
 msgid "Expected language \"%lang:1\" but got \"%prev:2\"."
 msgstr "Очікувалась мова \"%lang:1\" але отримано \"%prev:2\"."
 
@@ -1290,6 +1286,16 @@ msgstr "теґи HTML, які розпочинають блок HTML, який �
 msgid "filter for dealing with Nroff documents"
 msgstr "фільтр для роботи з документами Nroff"
 
+#: modules/filter/po-filter.info:7
+#, fuzzy
+#| msgid "filter for dealing with Texinfo documents"
+msgid "filter to deal with gettext .po files"
+msgstr "фільтр для роботи з документами Texinfo"
+
+#: modules/filter/po-filter.info:13
+msgid "review only msgids"
+msgstr ""
+
 #: modules/filter/sgml-filter.info:9
 msgid "filter for dealing with generic SGML/XML documents"
 msgstr "фільтр для роботи зі звичайними SGML/XML документами"
@@ -1361,6 +1367,12 @@ msgstr "режим для перевірки документів Nroff"
 #: modules/filter/modes/perl.amf:8
 msgid "mode for checking Perl comments and string literals"
 msgstr "режим для перевірки коментарів perl та символьних літералів"
+
+#: modules/filter/modes/po.amf:7
+#, fuzzy
+#| msgid "mode for checking Texinfo documents"
+msgid "mode for checking gettext .po files"
+msgstr "режим для перевірки документів Texinfo"
 
 #: modules/filter/modes/sgml.amf:8
 msgid "mode for checking generic SGML/XML documents"

--- a/po/vi.po
+++ b/po/vi.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aspell 0.60.7\n"
 "Report-Msgid-Bugs-To: kevina@gnu.org\n"
-"POT-Creation-Date: 2023-12-19 16:19-0500\n"
+"POT-Creation-Date: 2025-06-16 20:23-0500\n"
 "PO-Revision-Date: 2012-03-13 14:59+0700\n"
 "Last-Translator: Trần Ngọc Quân <vnwildman@gmail.com>\n"
 "Language-Team: Vietnamese <vi-VN@googlegroups.com>\n"
@@ -457,7 +457,6 @@ msgid "The key \"%key:1\" does not take any parameters when prefixed by a \"clea
 msgstr "Khóa « %key:1 » không chấp nhận tham số khi có tiền tố « clear- » (xóa)."
 
 #: common/errors.cpp:235
-#, c-format
 msgid "The language \"%lang:1\" is not known."
 msgstr "Không biết ngôn ngữ « %lang:1 »."
 
@@ -467,17 +466,14 @@ msgid "The soundslike \"%sl:2\" is not known."
 msgstr "Không biết điều soundslike (nghe như) « %sl:2 »."
 
 #: common/errors.cpp:251
-#, c-format
 msgid "The language \"%lang:1\" is not supported."
 msgstr "Ngôn ngữ « %lang:1 » không được hỗ trợ."
 
 #: common/errors.cpp:259
-#, c-format
 msgid "No word lists can be found for the language \"%lang:1\"."
 msgstr "Không tìm thấy danh sách từ đối với ngôn ngữ « %lang:1 »."
 
 #: common/errors.cpp:267
-#, c-format
 msgid "Expected language \"%lang:1\" but got \"%prev:2\"."
 msgstr "Ngờ ngôn ngữ « %lang:1 » còn nhận « %prev:2 »."
 
@@ -1320,6 +1316,16 @@ msgstr ""
 msgid "filter for dealing with Nroff documents"
 msgstr "bộ lọc để xử lý tài liệu Nroff"
 
+#: modules/filter/po-filter.info:7
+#, fuzzy
+#| msgid "filter for dealing with Texinfo documents"
+msgid "filter to deal with gettext .po files"
+msgstr "bộ lọc để xử lý tài liệu Texinfo"
+
+#: modules/filter/po-filter.info:13
+msgid "review only msgids"
+msgstr ""
+
 #: modules/filter/sgml-filter.info:9
 msgid "filter for dealing with generic SGML/XML documents"
 msgstr "bộ lọc để xử lý tài liệu SGML/XML giống loài"
@@ -1393,6 +1399,12 @@ msgstr "chế độ để kiểm tra tài liệu Nroff"
 #: modules/filter/modes/perl.amf:8
 msgid "mode for checking Perl comments and string literals"
 msgstr "chế độ để kiểm tra chú thích Perl và đồ nghĩa chữ trong chuỗi"
+
+#: modules/filter/modes/po.amf:7
+#, fuzzy
+#| msgid "mode for checking Texinfo documents"
+msgid "mode for checking gettext .po files"
+msgstr "chế độ để kiểm tra tài liệu Texinfo"
 
 #: modules/filter/modes/sgml.amf:8
 msgid "mode for checking generic SGML/XML documents"

--- a/po/wa.po
+++ b/po/wa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aspell 0.60.8-pre2\n"
 "Report-Msgid-Bugs-To: kevina@gnu.org\n"
-"POT-Creation-Date: 2019-09-24 03:02-0400\n"
+"POT-Creation-Date: 2025-06-16 20:23-0500\n"
 "PO-Revision-Date: 2019-10-27 16:22+0100\n"
 "Last-Translator: Pablo Saratxaga <pablo@walon.org>\n"
 "Language-Team: Walloon <(nothing)>\n"
@@ -453,7 +453,6 @@ msgid "The key \"%key:1\" does not take any parameters when prefixed by a \"clea
 msgstr "Li clé «%key:1» n' prind nén d' paramete s' i elle a «clear-» pa dvant"
 
 #: common/errors.cpp:235
-#, c-format
 msgid "The language \"%lang:1\" is not known."
 msgstr "Li lingaedje «%lang:1» n' est nén cnoxhou."
 
@@ -463,17 +462,14 @@ msgid "The soundslike \"%sl:2\" is not known."
 msgstr "L' infôrmåcion fonetike «%sl:2» n' est nén cnoxhowe."
 
 #: common/errors.cpp:251
-#, c-format
 msgid "The language \"%lang:1\" is not supported."
 msgstr "Li lingaedje «%lang:1» n' est nén sopoirté."
 
 #: common/errors.cpp:259
-#, c-format
 msgid "No word lists can be found for the language \"%lang:1\"."
 msgstr "Nole djivêye di mots d' trovêye pol lingaedje «%lang:1»."
 
 #: common/errors.cpp:267
-#, c-format
 msgid "Expected language \"%lang:1\" but got \"%prev:2\"."
 msgstr "Lingaedje «%lang:1» ratindou, mins c' est «%prev:2» ki dj' a-st avou."
 
@@ -684,8 +680,10 @@ msgid "Invalid Option: %s"
 msgstr "Tchuze nén valide: %s"
 
 #: prog/aspell.cpp:322
-msgid " does not take any parameters."
-msgstr ""
+#, fuzzy, c-format
+#| msgid "Does not contain any alphabetic characters."
+msgid "'%s' does not take any parameters."
+msgstr "I n' a nou caractere alfabetike."
 
 #: prog/aspell.cpp:335 prog/aspell.cpp:395
 #, c-format
@@ -946,7 +944,7 @@ msgstr ""
 #| "\n"
 msgid ""
 "\n"
-"Aspell %s.  Copyright 2000-2019 by Kevin Atkinson.\n"
+"Aspell %s.  Copyright 2000-2023 by Kevin Atkinson.\n"
 "\n"
 msgstr ""
 "\n"
@@ -1209,7 +1207,7 @@ msgstr "Li longueur totåle do mot, avou les dnêyes fonetikes, est di pus d' 2
 msgid "There must be at least one \"add\" line."
 msgstr "I fåt pol moens ene roye «add»."
 
-#: modules/speller/default/suggest.cpp:1720
+#: modules/speller/default/suggest.cpp:1730
 msgid "one of ultra, fast, normal, slow, or bad-spellers"
 msgstr ""
 
@@ -1298,6 +1296,16 @@ msgstr "etiketes HTML k' atakèt on blok HTML ki ki finixh avou ene vude roye"
 msgid "filter for dealing with Nroff documents"
 msgstr "passete po les documints Nroff"
 
+#: modules/filter/po-filter.info:7
+#, fuzzy
+#| msgid "filter for dealing with Texinfo documents"
+msgid "filter to deal with gettext .po files"
+msgstr "passete po les documints Texinfo"
+
+#: modules/filter/po-filter.info:13
+msgid "review only msgids"
+msgstr ""
+
 #: modules/filter/sgml-filter.info:9
 msgid "filter for dealing with generic SGML/XML documents"
 msgstr "passete po les documints SGML/XML djenerikes"
@@ -1371,6 +1379,12 @@ msgstr "môde pol verifiaedje des documints Nroff"
 #: modules/filter/modes/perl.amf:8
 msgid "mode for checking Perl comments and string literals"
 msgstr "môde pol verifiaedje des comintåres eyet tchinnes di tecse dins des fitchîs perl"
+
+#: modules/filter/modes/po.amf:7
+#, fuzzy
+#| msgid "mode for checking Texinfo documents"
+msgid "mode for checking gettext .po files"
+msgstr "môde pol verifiaedje des documints Texinfo"
 
 #: modules/filter/modes/sgml.amf:8
 msgid "mode for checking generic SGML/XML documents"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aspell-0.60.8-pre2\n"
 "Report-Msgid-Bugs-To: kevina@gnu.org\n"
-"POT-Creation-Date: 2023-12-19 16:19-0500\n"
+"POT-Creation-Date: 2025-06-16 20:23-0500\n"
 "PO-Revision-Date: 2019-09-24 10:51-0400\n"
 "Last-Translator: Boyuan Yang <073plan@gmail.com>\n"
 "Language-Team: Chinese (simplified) <i18n-zh@googlegroups.com>\n"
@@ -452,7 +452,6 @@ msgid "The key \"%key:1\" does not take any parameters when prefixed by a \"clea
 msgstr "当键“%key:1”前缀为“clear-”时不带任何参数。"
 
 #: common/errors.cpp:235
-#, c-format
 msgid "The language \"%lang:1\" is not known."
 msgstr "语言“%lang:1”为未知。"
 
@@ -462,17 +461,14 @@ msgid "The soundslike \"%sl:2\" is not known."
 msgstr "soundslike “%sl:2”未知。"
 
 #: common/errors.cpp:251
-#, c-format
 msgid "The language \"%lang:1\" is not supported."
 msgstr "不支持语言“%lang:1”。"
 
 #: common/errors.cpp:259
-#, c-format
 msgid "No word lists can be found for the language \"%lang:1\"."
 msgstr "没有找到语言“%lang:1”的单词表。"
 
 #: common/errors.cpp:267
-#, c-format
 msgid "Expected language \"%lang:1\" but got \"%prev:2\"."
 msgstr "语言应为“%lang:1”但实际是“%prev:2”。"
 
@@ -1293,6 +1289,16 @@ msgstr ""
 msgid "filter for dealing with Nroff documents"
 msgstr "用于处理 Nroff 文档的过滤器"
 
+#: modules/filter/po-filter.info:7
+#, fuzzy
+#| msgid "filter for dealing with Texinfo documents"
+msgid "filter to deal with gettext .po files"
+msgstr "用于处理 Texinfo 文档的过滤器"
+
+#: modules/filter/po-filter.info:13
+msgid "review only msgids"
+msgstr ""
+
 #: modules/filter/sgml-filter.info:9
 msgid "filter for dealing with generic SGML/XML documents"
 msgstr "用于处理通用 SGML/XML 文档的过滤器"
@@ -1364,6 +1370,12 @@ msgstr "检查 Nroff 文档的模式"
 #: modules/filter/modes/perl.amf:8
 msgid "mode for checking Perl comments and string literals"
 msgstr "检查 Perl 注释和字符串字面值的模式"
+
+#: modules/filter/modes/po.amf:7
+#, fuzzy
+#| msgid "mode for checking Texinfo documents"
+msgid "mode for checking gettext .po files"
+msgstr "检查 Texinfo 文档的模式"
 
 #: modules/filter/modes/sgml.amf:8
 msgid "mode for checking generic SGML/XML documents"


### PR DESCRIPTION
Add filter for gettext files geared to translators

* There is an option for maintainers that allow to review msgid texts
* Includes documentation and update to aspell.po
* Adds translation to spanish and minor updates to es.po
* The cpp filter includes debug samples to allow others to inspect and maybe contribute with other filters
* Update on gitignore to exclude intermediate doc generated files and other intermediate files appropiate for lsp editors

Closes #410