### PR TITLE
CI: update with latest compilers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,7 +213,7 @@ jobs:
     # Note: Default GCC in 24.04 is GCC 13
     - run: sudo apt-get -y update
     - run: sudo apt-get -y install make autopoint texinfo libtool intltool bzip2 gettext g++-multilib
-         g++-13 g++-14 g++-14-multilib clang-16 clang-17 clang-18 clang-19 
+         g++-13 g++-14 g++-14-multilib clang-16 clang-17 clang-18 clang-19 clang-20
     - run: sudo apt-get -y purge aspell
     - checkout
     - run:
@@ -252,6 +252,9 @@ jobs:
         command: CXX=clang++-19 CC=clang-19 ./sanity-check.sh
     - run:
         when: always
+        command: CXX=clang++-20 CC=clang-20 ./sanity-check.sh
+    - run:
+        when: always
         command: ./config-opt && make -C build -j2
 
   build_snapshots:
@@ -278,9 +281,9 @@ jobs:
           wget https://apt.llvm.org/llvm.sh -O /tmp/llvm.sh
           chmod +x /tmp/llvm.sh
           
-          # Install Clang Latest (20 and 21)
-          sudo /tmp/llvm.sh 20
-          sudo /tmp/llvm.sh 21 all
+          # Install Clang Latest (21 and 22)
+          sudo /tmp/llvm.sh 21
+          sudo /tmp/llvm.sh 22 all
     - run: sudo apt-get -y purge aspell
     - checkout
     - run: ./autogen
@@ -297,10 +300,10 @@ jobs:
     # Clang Snapshot Test
     - run:
         when: always
-        command: CXX=clang++-20 CC=clang-20 ./sanity-check.sh
+        command: CXX=clang++-21 CC=clang-21 ./sanity-check.sh
     - run:
         when: always
-        command: CXX=clang++-21 CC=clang-21 ./sanity-check.sh
+        command: CXX=clang++-22 CC=clang-22 ./sanity-check.sh
 
 
   tests_20_04:


### PR DESCRIPTION
CircleCI images based on Ubuntu 26.04 should be available:
* [Ubuntu 22.04, 24.04, 26.04 - Q2 2026 Edge Release (Including CUDA)](https://discuss.circleci.com/t/ubuntu-22-04-24-04-26-04-q2-2026-edge-release-including-cuda/54579)
* [Ubuntu 22.04, 24.04, 26.04 - Q2 Current Release (Including CUDA)](https://discuss.circleci.com/t/ubuntu-22-04-24-04-26-04-q2-current-release-including-cuda/54590)

Not sure what the relation between [**cimg/base**](https://circleci.com/developer/images/image/cimg/base) images such as `cimg/base:current-24.04` and images like `ubuntu-24:04:current` could be.